### PR TITLE
[refactor]: oauth 주소를 backend 주소로 변경

### DIFF
--- a/next/src/app/(login)/login/page.tsx
+++ b/next/src/app/(login)/login/page.tsx
@@ -6,7 +6,7 @@ export default function Login() {
     <div>
       <RedirectBtn
         title="login"
-        redirectUrl="https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-fc98ac0844ad77b1a1932b5d97bfd44e98a5a42ed7f89f4140e6c7c6571f2aca&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Foauth&response_type=code"
+        redirectUrl="http://localhost:3000/api/auth/login"
       />
     </div>
   );


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
- #15

## 요약
- backend의 /api/auth/login으로 redirect를 설정해줬습니다.

<br><br>

## 작업내용
- login 페이지에서 link 주소를 backend로 변경

<br><br>

## 참고사항
- https://github.com/august-thirty-first/backend/pull/21

<br><br>
