### PR TITLE
[feat] profile query string으로 nickname 검색 설정

### DIFF
--- a/next/src/app/(home)/(communication)/profile/page.tsx
+++ b/next/src/app/(home)/(communication)/profile/page.tsx
@@ -4,6 +4,7 @@ import { useFetch } from '@/lib/useFetch';
 import SearchBar, { searchProfileResponse } from './searchBar';
 import Info from './info';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import Btn from '@/components/btn';
 import { useState } from 'react';
 import FriendBtn from './_friend/friendBtn';
@@ -21,6 +22,7 @@ const ProfilePage = () => {
       url: 'profile/me',
       method: 'GET',
     });
+  const nickname_params = useSearchParams().get('nickname');
   const [profile, setProfile] = useState<searchProfileResponse>();
   const isMyProfile = profile?.nickname === dataRef?.current?.nickname;
 
@@ -29,7 +31,7 @@ const ProfilePage = () => {
   return (
     <div>
       <SearchBar
-        myNickname={dataRef?.current?.nickname}
+        myNickname={nickname_params || dataRef?.current?.nickname}
         setProfile={setProfile}
       />
       <div>


### PR DESCRIPTION
- profile page에서 query string값으로 nickname 검색이 가능하게 설정

## 관련 이슈
- #71 

## 요약
- profile page에서 nickname 검색을 할 수 있게 query string 값을 받음

<br><br>

## 작업내용
http://localhost:4000/profile?nickname=test
이렇게 요청하면 됩니다. 없는 유저에 대해서는 아무런 Data가 나오지 않습니다..!

<br><br>

## 참고사항

<br><br>
