### PR TITLE
[bug] 소켓 disconnect logout 처리

### DIFF
--- a/next/src/components/logout.tsx
+++ b/next/src/components/logout.tsx
@@ -23,5 +23,10 @@ export default function Logout() {
     }
   };
 
+  socket.on('disconnect', () => {
+    alert('서버와의 연결이 끊어졌습니다. 다시 로그인해주세요.');
+    onClick();
+  });
+
   return <Btn handler={onClick} title="logout" />;
 }


### PR DESCRIPTION
## 관련 이슈
- #79

## 요약
- 소켓이 서버에서 disconnect시에, logout 처리하도록 했습니다!

<br><br>

## 작업내용
- jwtPayload에 nickname이 들어있기에, nickname update시에 새로운 jwtpayload를 설정해줬었음
- 이로인해 소켓을 서버에서 disconnect해도 클라이언트의 token은 정상상태인 경우가 있음.
- 예외 처리를 위해 client에서도 disconnect 됐을 시 logout 처리하도록 했습니다..!

<br><br>

## 참고사항

<br><br>
