### PR TITLE
Refactor 93 에러 모달 메세지 띄우기

### DIFF
--- a/next/src/app/(home)/(communication)/channel/_room/roomBuilder.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomBuilder.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import Modal from '@/components/modal/Modal';
 import ChatRoom from '@/interfaces/chatRoom.interface';
 import { useRouter } from 'next/navigation';
+import { useShowModal } from '@/app/ShowModalContext';
 
 export default function RoomBuilder({
   title,
@@ -16,6 +17,7 @@ export default function RoomBuilder({
   url: string;
 }) {
   const router = useRouter();
+  const alertModal = useShowModal();
   const [showModal, setShowModal] = useState(false);
   const [inputPassword, setInputPassword] = useState('');
   const [disablePassword, setDisablePassword] = useState(false);
@@ -65,9 +67,9 @@ export default function RoomBuilder({
     Todo: 성공했으면 반환된 채팅방에 redirect
      */
     if (statusCodeRef?.current === 200 || statusCodeRef?.current === 201) {
-      alert('성공!');
+      alertModal('성공!');
     } else {
-      alert('실패!');
+      alertModal('실패!');
     }
   }
 

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/delete.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/delete.tsx
@@ -2,11 +2,13 @@
 import { useFetch } from '@/lib/useFetch';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Btn from '@/components/btn';
+import { useShowModal } from '@/app/ShowModalContext';
 
 export default function RoomDelete() {
   const searchParams = useSearchParams();
   const roomId = searchParams.get('roomId');
   const router = useRouter();
+  const alertModal = useShowModal();
 
   const { isLoading, statusCodeRef, fetchData } = useFetch<void>({
     autoFetch: false,
@@ -22,10 +24,10 @@ export default function RoomDelete() {
 
     // Todo: 기존에 방에 참여하고 있었던 사용자에 대한 처리 필요
     if (statusCodeRef?.current === 200) {
-      alert('방 삭제 완료');
+      alertModal('방 삭제 완료');
       router.push(`/channel/`);
     } else {
-      alert('방 삭제 실패');
+      alertModal('방 삭제 실패');
     }
   }
 

--- a/next/src/app/(home)/(communication)/profile/_friend/friendActionBtn.tsx
+++ b/next/src/app/(home)/(communication)/profile/_friend/friendActionBtn.tsx
@@ -1,3 +1,4 @@
+import { useShowModal } from '@/app/ShowModalContext';
 import Btn from '@/components/btn';
 import { useFetch } from '@/lib/useFetch';
 import { useEffect } from 'react';
@@ -26,6 +27,7 @@ const FriendActionBtn = ({
     body: JSON.stringify({ userId }),
     contentType: 'application/json',
   });
+  const alertModal = useShowModal();
 
   useEffect(() => {
     bodyRef.current = JSON.stringify({ userId });
@@ -34,7 +36,7 @@ const FriendActionBtn = ({
   const onClick = async (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     await fetchData();
-    if (statusCodeRef?.current === successStatusCode) alert('요청 성공');
+    if (statusCodeRef?.current === successStatusCode) alertModal('요청 성공');
     refreshBtn();
   };
 

--- a/next/src/app/(home)/(communication)/profile/edit/nickname.tsx
+++ b/next/src/app/(home)/(communication)/profile/edit/nickname.tsx
@@ -3,6 +3,7 @@
 import Btn from '@/components/btn';
 import { Dispatch, SetStateAction } from 'react';
 import { useFetch } from '@/lib/useFetch';
+import { useShowModal } from '@/app/ShowModalContext';
 
 interface nicknameProps {
   nickname: string;
@@ -23,6 +24,7 @@ const EditNickname = ({ nickname, setNickname, validate }: nicknameProps) => {
       body: JSON.stringify({ nickname }),
       contentType: 'application/json',
     });
+  const alertModal = useShowModal();
 
   const onHandle = async (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
@@ -31,8 +33,8 @@ const EditNickname = ({ nickname, setNickname, validate }: nicknameProps) => {
     await fetchData();
     if (statusCodeRef?.current === 200 && dataRef?.current) {
       if (dataRef?.current.status === true)
-        alert('이미 존재하는 nickname 입니다.');
-      else alert('OK');
+        alertModal('이미 존재하는 nickname 입니다.');
+      else alertModal('OK');
     }
   };
 

--- a/next/src/app/(home)/(communication)/profile/edit/otpModal.tsx
+++ b/next/src/app/(home)/(communication)/profile/edit/otpModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Btn from '@/components/btn';
 import { useFetch } from '@/lib/useFetch';
+import { useShowModal } from '@/app/ShowModalContext';
 
 interface otpGetResponse {
   qrImage: string;
@@ -28,12 +29,13 @@ const OtpModal = ({ closeModal }: otpModalProps) => {
     url: 'profile/otp',
     method: 'GET',
   });
+  const alertModal = useShowModal();
 
   const validate = (): boolean => {
     const trim_token = token.trim();
     setToken(trim_token);
     if (trim_token.length === 0) {
-      alert('token을 입력해주세요.');
+      alertModal('token을 입력해주세요.');
       return false;
     }
     return true;
@@ -48,7 +50,7 @@ const OtpModal = ({ closeModal }: otpModalProps) => {
     });
     await otpSetupAPI.fetchData();
     if (otpSetupAPI.statusCodeRef?.current === 204) {
-      alert('OTP 설정 완료');
+      alertModal('OTP 설정 완료');
       closeModal();
     }
   };

--- a/next/src/app/(home)/(communication)/profile/edit/page.tsx
+++ b/next/src/app/(home)/(communication)/profile/edit/page.tsx
@@ -6,6 +6,7 @@ import Otp from './otp';
 import Avata from '@/app/(login)/signup/avata';
 import EditNickname from './nickname';
 import { useFetch } from '@/lib/useFetch';
+import { useShowModal } from '@/app/ShowModalContext';
 
 const Edit = () => {
   const { isLoading, statusCodeRef, bodyRef, fetchData } = useFetch<void>({
@@ -17,12 +18,13 @@ const Edit = () => {
   const [nickname, setNickname] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
   const router = useRouter();
+  const alertModal = useShowModal();
 
   const validate = (): boolean => {
     let trim_nickname = nickname.trim();
     setNickname(trim_nickname);
     if (trim_nickname.length === 0 && !file) {
-      alert('변경하실 닉네임 또는 사진을 넣어주세요.');
+      alertModal('변경하실 닉네임 또는 사진을 넣어주세요.');
       return false;
     }
     return true;
@@ -38,7 +40,7 @@ const Edit = () => {
     bodyRef.current = formData;
     await fetchData();
     if (statusCodeRef?.current === 204) {
-      alert('수정 완료');
+      alertModal('수정 완료.');
       router.replace('/profile');
     }
   };

--- a/next/src/app/(home)/(communication)/profile/searchBar.tsx
+++ b/next/src/app/(home)/(communication)/profile/searchBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useShowModal } from '@/app/ShowModalContext';
 import { useFetch } from '@/lib/useFetch';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import useSWR from 'swr';
@@ -30,13 +31,14 @@ const SearchBar = ({ myNickname, setProfile }: searchBarProps) => {
       url: `profile/user?nickname=${nickname}`,
       method: 'GET',
     });
+  const alertModal = useShowModal();
   const { data } = useSWR('/searchBar', fetchData);
 
   const validate = (): boolean => {
     let trim_nickname = nickname.trim();
     setNickname(trim_nickname);
     if (trim_nickname.length === 0) {
-      alert('닉네임에 빈 문자열을 입력하면 안됩니다.');
+      alertModal('닉네임에 빈 문자열을 입력하면 안됩니다.');
       return false;
     }
     return true;
@@ -48,7 +50,7 @@ const SearchBar = ({ myNickname, setProfile }: searchBarProps) => {
     await fetchData();
     if (statusCodeRef?.current === 200) {
       if (dataRef?.current) setProfile(dataRef.current);
-      else alert('찾을 수 없는 사용자입니다.');
+      else alertModal('찾을 수 없는 사용자입니다.');
     }
   };
 

--- a/next/src/app/(login)/otp/page.tsx
+++ b/next/src/app/(login)/otp/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useShowModal } from '@/app/ShowModalContext';
 import { useFetch } from '@/lib/useFetch';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -7,6 +8,7 @@ import { useState } from 'react';
 const OtpLogin = () => {
   const [token, setToken] = useState<string>('');
   const router = useRouter();
+  const alertModal = useShowModal();
   const { statusCodeRef, bodyRef, fetchData } = useFetch<void>({
     autoFetch: false,
     url: 'auth/otp',
@@ -19,7 +21,7 @@ const OtpLogin = () => {
     const token_trim = token.trim();
     setToken(token_trim);
     if (token_trim.length === 0) {
-      alert('토큰 값을 입력해주세요.');
+      alertModal('토큰 값을 입력해주세요.');
       return false;
     }
     return true;

--- a/next/src/app/(login)/signup/avata.tsx
+++ b/next/src/app/(login)/signup/avata.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useShowModal } from '@/app/ShowModalContext';
 import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 
 interface avataProps {
@@ -8,13 +9,14 @@ interface avataProps {
 }
 
 const Avata = ({ file, setFile }: avataProps) => {
+  const alertModal = useShowModal();
   const onHandler = (event: ChangeEvent<HTMLInputElement>) => {
     const maxFileSize = 1024 * 1024 * 1;
     const files = event.target.files;
     if (files && files[0]) {
       const cur_file = files[0];
       if (cur_file.size >= maxFileSize) {
-        alert('파일 크기는 1MB까지만 가능합니다.');
+        alertModal('파일 크기는 1MB까지만 가능합니다.');
         event.target.value = '';
         setFile(null);
       } else setFile(files[0]);

--- a/next/src/app/(login)/signup/nickname.tsx
+++ b/next/src/app/(login)/signup/nickname.tsx
@@ -3,6 +3,7 @@
 import Btn from '@/components/btn';
 import { Dispatch, SetStateAction } from 'react';
 import { useFetch } from '@/lib/useFetch';
+import { useShowModal } from '@/app/ShowModalContext';
 
 interface nicknameResponse {
   status: boolean;
@@ -23,6 +24,7 @@ const Nickname = ({ nickname, setNickname, validate }: nicknameProps) => {
       body: JSON.stringify({ nickname }),
       contentType: 'application/json',
     });
+  const alertModal = useShowModal();
 
   const onHandle = async (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
@@ -31,8 +33,8 @@ const Nickname = ({ nickname, setNickname, validate }: nicknameProps) => {
     await fetchData();
     if (statusCodeRef?.current === 200) {
       if (dataRef?.current?.status === true)
-        alert('이미 존재하는 nickname 입니다.');
-      else alert('OK');
+        alertModal('이미 존재하는 nickname 입니다.');
+      else alertModal('OK');
     }
   };
 

--- a/next/src/app/(login)/signup/page.tsx
+++ b/next/src/app/(login)/signup/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import Nickname from './nickname';
 import Avata from './avata';
 import { useFetch } from '@/lib/useFetch';
+import { useShowModal } from '@/app/ShowModalContext';
 
 export default function SignUp() {
   const { isLoading, statusCodeRef, bodyRef, fetchData } = useFetch<void>({
@@ -17,12 +18,13 @@ export default function SignUp() {
   const [nickname, setNickname] = useState<string>('');
   const [file, setFile] = useState<File | null>(null);
   const router = useRouter();
+  const alertModal = useShowModal();
 
   const validate = (): boolean => {
     let trim_nickname = nickname.trim();
     setNickname(trim_nickname);
     if (trim_nickname.length === 0) {
-      alert('닉네임에 빈 문자열을 입력하면 안됩니다.');
+      alertModal('닉네임에 빈 문자열을 입력하면 안됩니다.');
       return false;
     }
     return true;
@@ -38,7 +40,7 @@ export default function SignUp() {
     bodyRef.current = formData;
     await fetchData();
     if (statusCodeRef?.current === 200) {
-      alert('회원가입 성공');
+      alertModal('회원가입 성공');
       router.replace('/');
     }
   };

--- a/next/src/app/ShowModalContext.tsx
+++ b/next/src/app/ShowModalContext.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Modal from '@/components/modal/Modal';
+import ModalContent from '@/components/modal/ModalContent';
+import ModalHeader from '@/components/modal/ModalHeader';
+import {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+export interface ShowModalProviderValue {
+  showModal: boolean;
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+  setMessage: Dispatch<SetStateAction<string>>;
+}
+
+const ShowModalContext = createContext<ShowModalProviderValue | null>(null);
+
+const ShowModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>('');
+  return (
+    <ShowModalContext.Provider
+      value={{
+        showModal: showModal,
+        setShowModal: setShowModal,
+        setMessage: setMessage,
+      }}
+    >
+      {showModal && (
+        <Modal closeModal={setShowModal}>
+          <ModalHeader title="메세지" />
+          <ModalContent>{message}</ModalContent>
+        </Modal>
+      )}
+      {children}
+    </ShowModalContext.Provider>
+  );
+};
+
+export const useShowModal = () => {
+  const context = useContext<ShowModalProviderValue | null>(ShowModalContext);
+
+  return useCallback(
+    (message: string) => {
+      if (!context?.showModal) {
+        context?.setMessage(message);
+        context?.setShowModal(true);
+      }
+    },
+    [context],
+  );
+};
+
+export default ShowModalProvider;

--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@/style/globals.css';
 
 import { Metadata } from 'next';
+import ShowModalProvider from './ShowModalContext';
 
 export const metadata: Metadata = {
   title: 'home',
@@ -16,7 +17,9 @@ export default function RootLayout({
       <head>
         <link rel="stylesheet" href="https://unpkg.com/mvp.css"></link>
       </head>
-      <body>{children}</body>
+      <body>
+        <ShowModalProvider>{children}</ShowModalProvider>
+      </body>
     </html>
   );
 }

--- a/next/src/components/logout.tsx
+++ b/next/src/components/logout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
+import { useShowModal } from '@/app/ShowModalContext';
 import { useRouter } from 'next/navigation';
 import { useContext } from 'react';
 import Btn from './btn';
@@ -9,6 +10,7 @@ export default function Logout() {
   const socket = useContext(HomeSocketContext);
   const router = useRouter();
   const backend_url = 'http://localhost:3000/api';
+  const alertModal = useShowModal();
 
   const onClick = async () => {
     try {
@@ -19,18 +21,18 @@ export default function Logout() {
       if (socket.connected) socket.disconnect();
       router.replace('/login');
     } catch (error: any) {
-      alert(`Error during logout: ${error.message}`);
+      alertModal(`Error during logout: ${error.message}`);
     }
   };
 
   socket.on('multipleConnect', () => {
-    alert('다중 로그인 상태입니다.');
+    alertModal('다중 로그인 상태입니다.');
     router.push('/login');
     socket.disconnect();
   });
 
   socket.on('expired', () => {
-    alert('서버와의 연결이 끊어졌습니다. 다시 로그인해주세요.');
+    alertModal('서버와의 연결이 끊어졌습니다. 다시 로그인해주세요.');
     onClick();
   });
 

--- a/next/src/lib/useFetch.ts
+++ b/next/src/lib/useFetch.ts
@@ -95,7 +95,8 @@ export function useFetch<T>({
 
   useEffect(() => {
     if (autoFetch) fetchData();
-  }, [fetchData, autoFetch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     isLoading,

--- a/next/src/lib/useFetch.ts
+++ b/next/src/lib/useFetch.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
+import { useShowModal } from '@/app/ShowModalContext';
 import { useRouter } from 'next/navigation';
 import {
   useEffect,
@@ -47,6 +48,7 @@ export function useFetch<T>({
   const dataRef = useRef<T>();
   const backend_url = 'http://localhost:3000/api/';
   const router = useRouter();
+  const alertModal = useShowModal();
 
   const fetchData = useCallback(async (): Promise<T | undefined> => {
     try {
@@ -80,18 +82,18 @@ export function useFetch<T>({
         const errorMsg = errorDataRef.current.message;
         if (response.status === 401 && errorMsg === 'UNAUTHORIZED') {
           if (socket.connected) socket.disconnect();
-          alert('다시 로그인을 해주세요.');
+          alertModal('다시 로그인을 해주세요.');
           router.push('/login');
-        } else alert(errorMsg);
+        } else alertModal(errorMsg);
       }
       return dataRef.current;
     } catch (error: any) {
       error.current = error.message;
-      alert(error.message);
+      alertModal(error.message);
     } finally {
       setIsLoading(false);
     }
-  }, [urlRef, contentType, method, bodyRef, router, socket]);
+  }, [urlRef, contentType, method, bodyRef, router, socket, alertModal]);
 
   useEffect(() => {
     if (autoFetch) fetchData();


### PR DESCRIPTION
## 관련 이슈
- #93 

## 요약
- 다들 아시다싶이 alert는 여러모로 단점이 존재하였음.
- 전역 modal을 설정해서, 메세지를 띄우게 설정
- useFetch 에러 fix

<br><br>

## 작업내용
- ShowModalContext를 app layout으로 감싸서, 전역적으로 보일 수 있게 설정
- useShowModal hook을 통해, showModal 처리를 쉽게 사용
- useFetch 사용시에 authFetch시에 re-rendering시에 다시 fetch가 되는 이슈가 있었음.
- useEffect dependency를 empty로 설정해서 mount 된 시점에서만 fetchData를 실행하게끔 설정했음
- alert -> alertModal로 변경
<img width="1486" alt="스크린샷 2" src="https://github.com/august-thirty-first/frontend/assets/48037775/bcdd2fe5-7d2c-4aec-b894-429d9945238e">
<img width="1465" alt="스크린샷 3" src="https://github.com/august-thirty-first/frontend/assets/48037775/77866fbb-20b5-4503-85e5-60fcf72b2543">


<br><br>

## 참고사항
**- 긴급 issue라고 생각해서 release2.0으로 PR 신청, 추후 토의 통해 dev-user로 PR 변경 가능**

<br><br>
