### PR TITLE
Feat chat 채팅방 나가기

### DIFF
--- a/next/src/app/(home)/(communication)/channel/MyParticipantInfoContext.tsx
+++ b/next/src/app/(home)/(communication)/channel/MyParticipantInfoContext.tsx
@@ -1,0 +1,36 @@
+'use client';
+import {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useState,
+} from 'react';
+import ChatParticipant from '@/interfaces/chatParticipant.interface';
+export const MyParticipantInfoContext = createContext<
+  [
+    ChatParticipant | undefined,
+    Dispatch<SetStateAction<ChatParticipant | undefined>>,
+  ]
+>([undefined, () => {}]);
+
+export default function MyParticipantInfoProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const myParticipantInfo = useState<ChatParticipant>();
+  return (
+    <MyParticipantInfoContext.Provider value={myParticipantInfo}>
+      {children}
+    </MyParticipantInfoContext.Provider>
+  );
+}
+
+export function useMyParticipantInfo() {
+  const value = useContext(MyParticipantInfoContext);
+  if (value === undefined) {
+    throw new Error('채팅방이 선택되지 않았습니다.');
+  }
+  return value;
+}

--- a/next/src/app/(home)/(communication)/channel/MyParticipantInfoContext.tsx
+++ b/next/src/app/(home)/(communication)/channel/MyParticipantInfoContext.tsx
@@ -28,9 +28,5 @@ export default function MyParticipantInfoProvider({
 }
 
 export function useMyParticipantInfo() {
-  const value = useContext(MyParticipantInfoContext);
-  if (value === undefined) {
-    throw new Error('채팅방이 선택되지 않았습니다.');
-  }
-  return value;
+  return useContext(MyParticipantInfoContext);
 }

--- a/next/src/app/(home)/(communication)/channel/_room/roomDetails.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomDetails.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import Btn from '@/components/btn';
+import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 
 export default function RoomDetails({
   room,
@@ -12,6 +13,7 @@ export default function RoomDetails({
   joinAPI: string;
 }) {
   const router = useRouter();
+  const [, setMyParcitipantInfo] = useMyParticipantInfo();
   const { isLoading, statusCodeRef, dataRef, bodyRef, fetchData } =
     useFetch<ChatParticipant>({
       autoFetch: false,
@@ -34,6 +36,7 @@ export default function RoomDetails({
     if (statusCodeRef?.current !== undefined && statusCodeRef?.current >= 400) {
       router.push('/channel');
     } else {
+      setMyParcitipantInfo(dataRef?.current);
       router.push(`/channel/chat/${room.id}`);
     }
   }

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
@@ -1,0 +1,38 @@
+import { useParams, useRouter } from 'next/navigation';
+import { useFetch } from '@/lib/useFetch';
+import Btn from '@/components/btn';
+import { useContext } from 'react';
+import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
+import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
+import { ParticipantAuthority } from '@/interfaces/chatParticipant.interface';
+
+export default function RoomLeave() {
+  const params = useParams();
+  const roomId = params.id;
+  const router = useRouter();
+  const socket = useContext(HomeSocketContext);
+  const [myParticipantInfo] = useMyParticipantInfo();
+
+  const { isLoading, statusCodeRef, fetchData } = useFetch<void>({
+    autoFetch: false,
+    method: 'DELETE',
+    url: `chat/participant/leave/${roomId}`,
+  });
+
+  // Todo: 기존에 방에 참여하고 있었던 사용자에 대한 처리 필요
+  // socket.on('leaveRoom', () => {
+  //   leaveRoom();
+  // });
+
+  async function leaveRoom() {
+    await fetchData();
+
+    // if i am boss? send leaveRoom event
+    // if (myParticipantInfo?.authority === ParticipantAuthority.BOSS) {
+    //   socket.emit('leaveRoom', JSON.stringify({ roomId: roomId }));
+    // }
+    router.push(`/channel/`);
+  }
+
+  return <Btn title={'방 나가기'} type={'button'} handler={leaveRoom} />;
+}

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -6,11 +6,16 @@ import RoomDelete from '@/app/(home)/(communication)/channel/chat/[id]/delete';
 import RoomBuilder from '@/app/(home)/(communication)/channel/_room/roomBuilder';
 import { useParams, useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
-import ChatParticipant from '@/interfaces/chatParticipant.interface';
+import ChatParticipant, {
+  ParticipantAuthority,
+} from '@/interfaces/chatParticipant.interface';
+import RoomLeave from '@/app/(home)/(communication)/channel/chat/[id]/leave';
+import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 
 export default function Chat() {
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
+  const [myParticipantInfo] = useMyParticipantInfo();
   const params = useParams();
   const roomId = params.id;
   const { isLoading, statusCodeRef, dataRef, bodyRef } = useFetch<
@@ -33,12 +38,18 @@ export default function Chat() {
       <div>
         <ChatBox />
         {/*Todo: 유저의 권한에 대해 확인하고 RoomDelete, RoomUpdate 두 컴포넌트를 보이게 하는 코드 필요*/}
-        <RoomDelete />
-        <RoomBuilder
-          title={'방 수정'}
-          method={'PATCH'}
-          url={`chat/${roomId}`}
-        />
+        <RoomLeave />
+        {(myParticipantInfo?.authority === ParticipantAuthority.BOSS ||
+          myParticipantInfo?.authority === ParticipantAuthority.ADMIN) && (
+          <>
+            <RoomDelete />
+            <RoomBuilder
+              title={'방 수정'}
+              method={'PATCH'}
+              url={`chat/${roomId}`}
+            />
+          </>
+        )}
       </div>
     )
   );

--- a/next/src/app/(home)/(communication)/channel/layout.tsx
+++ b/next/src/app/(home)/(communication)/channel/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import AllRoomList from '@/app/(home)/(communication)/channel/_room/allRoomList';
 import RoomBuilder from '@/app/(home)/(communication)/channel/_room/roomBuilder';
 import MyRoomList from '@/app/(home)/(communication)/channel/_room/myRoomList';
+import MyParticipantInfoProvider from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 
 export const metadata: Metadata = {
   title: 'channel',
@@ -11,14 +12,16 @@ export const metadata: Metadata = {
 
 export default function ChannelLayout({ children }: childrenProps) {
   return (
-    <div>
-      <h1>Channel</h1>
-      <div style={{ display: 'flex', gap: '200px' }}>
-        <AllRoomList />
-        <MyRoomList />
-        <RoomBuilder title={'방 생성'} method={'POST'} url={'chat'} />
-        {children}
+    <MyParticipantInfoProvider>
+      <div>
+        <h1>Channel</h1>
+        <div style={{ display: 'flex', gap: '200px' }}>
+          <AllRoomList />
+          <MyRoomList />
+          <RoomBuilder title={'방 생성'} method={'POST'} url={'chat'} />
+          {children}
+        </div>
       </div>
-    </div>
+    </MyParticipantInfoProvider>
   );
 }

--- a/next/src/app/(home)/(communication)/channel/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useRef, useContext, useEffect, useState } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
-import EnterRoom from '@/app/(home)/(communication)/channel/enterRoom';
 
 export default function Channel() {
   const socket = useContext(HomeSocketContext);


### PR DESCRIPTION
## 관련 이슈
- #51 

## 요약
- 채팅방 내부의 내 정보 context에 저장
- 채팅방 나가기 기능 구현

<br><br>

## 작업내용
- 내 닉네임, 권한 등 채팅방에서 필요한 자신의 정보를 불러오는 context에 저장하여 다른 컴포넌트에서 사용할 수 있도록 작성했습니다. useState를 사용하여 동적으로 데이터를 관리합니다..
- 방 수정, 방 삭제 버튼을 권한이 있는 유저만 볼 수 있도록 수정했습니다.
- 방 나가기 기능을 구현했습니다. 

<br><br>

## 참고사항
- 현재 나가기 기능을 http로만 처리했는데, boss가 나가 방이 삭제될 때 
남아있는 유저들에 대한 socket 이벤트 처리가 필요합니다.

<br><br>
