### PR TITLE
Feat 게임 종료 상태시 모달 창으로 종료 알리기

### DIFF
--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -21,11 +21,6 @@ const GameScreen: React.FC = () => {
     useRef<HTMLCanvasElement>(null);
   const router = useRouter();
 
-  const modalCloseFunction = () => {
-    setShowModal(false);
-    //do something
-  };
-
   let message = 'YOU WIN!'; /*임시*/
   socket.on('gameOver', gameHistory => {
     const json = JSON.parse(gameHistory);
@@ -124,7 +119,7 @@ const GameScreen: React.FC = () => {
     };
   }, []);
 
-  const onClickHandler = () => {
+  const modalCloseFunction = () => {
     if (socket.connected) socket.disconnect();
     router.push('/profile');
   };
@@ -133,12 +128,12 @@ const GameScreen: React.FC = () => {
     <div>
       <canvas ref={canvasRef} />
       {showModal && (
-        <Modal closeModal={setShowModal}>
+        <Modal closeModal={modalCloseFunction}>
           <ModalHeader title="GAME OVER" />
           <ModalContent>
             <p>{message}</p>
             <div>
-              <Btn type="button" title="홈으로" handler={onClickHandler} />
+              <Btn type="button" title="홈으로" handler={modalCloseFunction} />
             </div>
           </ModalContent>
         </Modal>

--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -8,6 +8,7 @@ import Modal from '@/components/modal/Modal';
 import ModalContent from '@/components/modal/ModalContent';
 import Btn from '@/components/btn';
 import ModalHeader from '@/components/modal/ModalHeader';
+import { useRouter } from 'next/navigation';
 
 //사용자의 환경에 따라 보내준다. 지금은 임시로 고정값으로 설정.
 const CLIENT_WIDTH = 1000;
@@ -19,6 +20,7 @@ const GameScreen: React.FC = () => {
   const [showModal, setShowModal] = useState<boolean>(true /*임시*/);
   const canvasRef: RefObject<HTMLCanvasElement> =
     useRef<HTMLCanvasElement>(null);
+  const router = useRouter();
 
   const modalCloseFunction = () => {
     setShowModal(false);
@@ -114,6 +116,11 @@ const GameScreen: React.FC = () => {
     }
   }, [socket]);
 
+  const onClickHandler = () => {
+    if (socket.connected) socket.disconnect();
+    router.push('/profile');
+  };
+
   return (
     <div>
       <canvas ref={canvasRef} />
@@ -123,7 +130,7 @@ const GameScreen: React.FC = () => {
           <ModalContent>
             <p>{message}</p>
             <div>
-              <Btn title="홈으로" />
+              <Btn type="button" title="홈으로" handler={onClickHandler} />
             </div>
           </ModalContent>
         </Modal>

--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -16,18 +16,18 @@ const CLIENT_HEIGHT = 500;
 const GameScreen: React.FC = () => {
   let renderInfo = new RenderInfo(); //빈 객체로 초기화
   const socket = useContext(GameSocketContext);
-  const [showModal, setShowModal] = useState<boolean>(true /*임시*/);
+  const [showModal, setShowModal] = useState<boolean>(false);
   const canvasRef: RefObject<HTMLCanvasElement> =
     useRef<HTMLCanvasElement>(null);
   const router = useRouter();
 
-  let message = 'YOU WIN!'; /*임시*/
+  let message;
   socket.on('gameOver', gameHistory => {
     const json = JSON.parse(gameHistory);
     if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
-      message = 'YOU WIN!';
+      message = '이겼다!';
     } else {
-      message = 'YOU LOSE..';
+      message = '졌다..';
     }
     setShowModal(true);
   });
@@ -129,7 +129,7 @@ const GameScreen: React.FC = () => {
       <canvas ref={canvasRef} />
       {showModal && (
         <Modal closeModal={modalCloseFunction}>
-          <ModalHeader title="GAME OVER" />
+          <ModalHeader title="게임오버" />
           <ModalContent>
             <p>{message}</p>
             <div>

--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -5,6 +5,9 @@ import { GameSocketContext } from '../createGameSocketContext';
 import RenderInfo from './renderInfo';
 import GamePlayer from './classes/gamePlayer';
 import Modal from '@/components/modal/Modal';
+import ModalContent from '@/components/modal/ModalContent';
+import Btn from '@/components/btn';
+import ModalHeader from '@/components/modal/ModalHeader';
 
 //사용자의 환경에 따라 보내준다. 지금은 임시로 고정값으로 설정.
 const CLIENT_WIDTH = 1000;
@@ -13,7 +16,7 @@ const CLIENT_HEIGHT = 500;
 const GameScreen: React.FC = () => {
   const socket = useContext(GameSocketContext);
   let renderInfo = new RenderInfo(); //빈 객체로 초기화
-  const [showModal, setShowModal] = useState<boolean>(false);
+  const [showModal, setShowModal] = useState<boolean>(true /*임시*/);
   const canvasRef: RefObject<HTMLCanvasElement> =
     useRef<HTMLCanvasElement>(null);
 
@@ -21,6 +24,17 @@ const GameScreen: React.FC = () => {
     setShowModal(false);
     //do something
   };
+
+  let message = 'YOU WIN!'; /*임시*/
+  socket.on('gameOver', gameHistory => {
+    const json = JSON.parse(gameHistory);
+    if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
+      message = 'YOU WIN!';
+    } else {
+      message = 'YOU LOSE..';
+    }
+    setShowModal(true);
+  });
 
   //처음에 한 번만 보내준다
   socket.emit(
@@ -30,13 +44,6 @@ const GameScreen: React.FC = () => {
       clientHeight: CLIENT_HEIGHT,
     }),
   );
-
-  socket.on('gameOver', gameHistory => {
-    const json = JSON.parse(gameHistory);
-    if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
-      //모달 바디에 들어갈 텍스트를 설정해준다.
-    }
-  });
 
   //정보 업데이트. 15ms에 한 번씩 온다
   socket.on('updateRenderInfo', data => {
@@ -112,7 +119,13 @@ const GameScreen: React.FC = () => {
       <canvas ref={canvasRef} />
       {showModal && (
         <Modal closeModal={setShowModal}>
-          {<div>contents of the modal</div>}
+          <ModalHeader title="GAME OVER" />
+          <ModalContent>
+            <p>{message}</p>
+            <div>
+              <Btn title="홈으로" />
+            </div>
+          </ModalContent>
         </Modal>
       )}
     </div>

--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -55,20 +55,19 @@ const GameScreen: React.FC = () => {
     //게임이 끝나면 모달창을 띄운다
     const gameOverListener = (gameHistory: any) => {
       const json = JSON.parse(gameHistory);
-      //TODO: null값이 들어온다 (createHistory 안되는 듯)
-      setMessage('이겼다!');
-      // if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
-      //   setMessage('이겼다!');
-      // } else {
-      //   setMessage('졌다..');
-      // }
+      if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
+        //혼자 테스트할 경우 항상 '이겼다'
+        setMessage('이겼다!');
+      } else {
+        setMessage('졌다..');
+      }
       setShowModal(true);
     };
     socket.on('gameOver', gameOverListener);
 
     //중간에 상대방 소켓이 끊어졌을 때 같은 모달창을 띄운다
     const gameOverInPlayingListener = () => {
-      // setMessage('버텨서 이겼다!');
+      setMessage('버텨서 이겼다!');
       setShowModal(true);
     };
     socket.on('gameOverInPlaying', gameOverInPlayingListener);

--- a/next/src/app/(home)/(game)/layout.tsx
+++ b/next/src/app/(home)/(game)/layout.tsx
@@ -1,10 +1,13 @@
 import childrenProps from '@/interfaces/childrenProps.interface';
 import GameSocketProvider from './createGameSocketContext';
+import ModalProvider from './modalProvider';
 
 export default function GameLayout({ children }: childrenProps) {
   return (
     <div>
-      <GameSocketProvider>{children}</GameSocketProvider>
+      <GameSocketProvider>
+        <ModalProvider>{children}</ModalProvider>
+      </GameSocketProvider>
     </div>
   );
 }

--- a/next/src/app/(home)/(game)/modalProvider.tsx
+++ b/next/src/app/(home)/(game)/modalProvider.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Btn from '@/components/btn';
+import Modal from '@/components/modal/Modal';
+import ModalContent from '@/components/modal/ModalContent';
+import ModalHeader from '@/components/modal/ModalHeader';
+import { createContext, useContext, useState } from 'react';
+import { GameSocketContext } from './createGameSocketContext';
+import { useRouter } from 'next/navigation';
+
+export interface ModalContextProps {
+  openModal: (message: string) => void;
+}
+
+const ModalContext = createContext<ModalContextProps | undefined>(undefined);
+
+export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [showModal, setShowModal] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const socket = useContext(GameSocketContext);
+  const router = useRouter();
+
+  const openModal = (msg: any) => {
+    setMessage(msg);
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setMessage('');
+    if (socket.connected) socket.disconnect();
+    router.push('/profile');
+  };
+
+  return (
+    <ModalContext.Provider value={{ openModal }}>
+      {children}
+      {showModal && (
+        <Modal closeModal={closeModal}>
+          <ModalHeader title="이제 그만" />
+          <ModalContent>
+            <p>{message}</p>
+            <div>
+              <Btn type="button" title="홈으로" handler={closeModal} />
+            </div>
+          </ModalContent>
+        </Modal>
+      )}
+    </ModalContext.Provider>
+  );
+};
+
+export const useModal = (): ModalContextProps => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModal must be used within a ModalProvider');
+  }
+  return context;
+};
+
+export default ModalProvider;

--- a/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
+++ b/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
@@ -6,10 +6,12 @@ import TypeSelection from './typeSelection';
 import React, { useContext, useEffect, useState } from 'react';
 import { GameSocketContext } from '@/app/(home)/(game)/createGameSocketContext';
 import { useRouter } from 'next/navigation';
+import { useModal } from '@/app/(home)/(game)/modalProvider';
 
 export default function GameOptionSubmitForm() {
   const socket = useContext(GameSocketContext);
   const router = useRouter();
+  const { openModal } = useModal();
 
   const [isTypeSelected, setIsTypeSelected] = useState<boolean>(false);
   const [isDifficultySelected, setIsDifficultySelected] =
@@ -42,6 +44,12 @@ export default function GameOptionSubmitForm() {
       router.push('/game');
     });
   }, [socket, router]);
+
+  //중간에 상대방 소켓이 끊어졌을 때 모달창을 띄운다
+  const gameOverInOptionPageListener = () => {
+    openModal('상대방이 떠났습니다..');
+  };
+  socket.on('gameOverInOptionPage', gameOverInOptionPageListener);
 
   return (
     <div>

--- a/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
+++ b/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
@@ -40,16 +40,22 @@ export default function GameOptionSubmitForm() {
   };
 
   useEffect(() => {
-    socket.on('gameStart', () => {
+    const gameStartListener = () => {
       router.push('/game');
-    });
-  }, [socket, router]);
+    };
+    socket.on('gameStart', gameStartListener);
 
-  //중간에 상대방 소켓이 끊어졌을 때 모달창을 띄운다
-  const gameOverInOptionPageListener = () => {
-    openModal('상대방이 떠났습니다..');
-  };
-  socket.on('gameOverInOptionPage', gameOverInOptionPageListener);
+    //중간에 상대방 소켓이 끊어졌을 때 모달창을 띄운다
+    const gameOverInOptionPageListener = () => {
+      openModal('상대방이 떠났습니다..');
+    };
+    socket.on('gameOverInOptionPage', gameOverInOptionPageListener);
+
+    return () => {
+      socket.off('gameStart', gameStartListener);
+      socket.off('gameOverInOptionPage', gameOverInOptionPageListener);
+    };
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
## 관련 이슈
- #86 

## 요약
옵션선택/게임을 중단/종료하고 홈으로 돌아가야 하는 경우 모달창으로 알린다
<br><br>

## 작업내용
상황: 게임 정상종료시 / 게임 중 종료시(상대방 소켓 끊김) / 옵션선택 중 종료시(상대방 소켓 끊김)
모달창을 game layout에 context로 제공하여 사용할 수 있도록 함 
(모달 header와 '홈으로 버튼' 공유, 안에 들어가는 message만 상황에 따라 변경)

<br><br>

## 참고사항
/game 하위 페이지에서 홈으로 돌아가야 하는 상황이 생기면 이 모달을 사용할 예정입니다
<br><br>
