### PR TITLE
114 user profile achivement 출력 및 layout 재구성

### DIFF
--- a/next/src/app/(home)/(communication)/profile/achievements.tsx
+++ b/next/src/app/(home)/(communication)/profile/achievements.tsx
@@ -1,0 +1,25 @@
+import { GetAchievementDto } from './searchBar';
+
+interface AchievementsProps {
+  achievements: GetAchievementDto[] | undefined;
+}
+
+const Achievements = ({ achievements }: AchievementsProps) => {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight sm:text-3xl mb-5">
+        Achievements
+      </h2>
+      {achievements &&
+        achievements.map(achievement => (
+          <>
+            <label key={achievement.title}>{achievement.title}</label>
+            <h3>{achievement.description}</h3>
+          </>
+        ))}
+      {achievements?.length === 0 && '달성한 업적이 없습니다...'}
+    </div>
+  );
+};
+
+export default Achievements;

--- a/next/src/app/(home)/(communication)/profile/info.tsx
+++ b/next/src/app/(home)/(communication)/profile/info.tsx
@@ -20,20 +20,18 @@ const Info = ({ profile }: InfoProps) => {
             disabled={true}
             value={profile.nickname}
           />
-          <div>
-            <label>Image</label>
-            <Image
-              width="200"
-              height="200"
-              className="h-36 w-auto"
-              src={
-                profile.avata_path
-                  ? `http://nestjs:3000/${profile.avata_path}`
-                  : defaultImg
-              }
-              alt="avatar"
-            />
-          </div>
+          <label>Image</label>
+          <Image
+            width="200"
+            height="200"
+            className="h-36 w-auto"
+            src={
+              profile.avata_path
+                ? `http://nestjs:3000/${profile.avata_path}`
+                : defaultImg
+            }
+            alt="avatar"
+          />
         </>
       )}
     </>

--- a/next/src/app/(home)/(communication)/profile/matchHistory.tsx
+++ b/next/src/app/(home)/(communication)/profile/matchHistory.tsx
@@ -1,0 +1,99 @@
+import defaultImg from '@/public/default.png';
+import Image from 'next/image';
+
+const MatchHistory = () => {
+  return (
+    <div>
+      <h2 className="text-3xl font-bold tracking-tight sm:text-3xl mb-5">
+        Match History
+      </h2>
+      <h3>총 전적 : N승 N패 | 점수 : N</h3>
+      <ul role="list" className="divide-y divide-gray-200">
+        <li className="py-3 sm:py-4">
+          <span className="inline-flex items-center text-xl font-semibold text-red-700 mb-3">
+            패배
+          </span>
+          <span className="ml-3 text-sm text-gray-500 truncate font-semibold">
+            ladder
+          </span>
+          <div className="flex items-center space-x-4">
+            <div className="flex-shrink-0">
+              <Image
+                width="200"
+                height="200"
+                className="h-8 w-8 rounded-full"
+                src={defaultImg}
+                alt="avatar"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">
+                nickname
+              </p>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-red-900 truncate">VS</p>
+            </div>
+            <div className="flex-shrink-0">
+              <Image
+                width="200"
+                height="200"
+                className="h-8 w-8 rounded-full"
+                src={defaultImg}
+                alt="avatar"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">
+                nickname
+              </p>
+            </div>
+          </div>
+        </li>
+        <li className="py-3 sm:py-4">
+          <span className="inline-flex items-center text-xl font-semibold text-blue-700 mb-3">
+            승리
+          </span>
+          <span className="ml-3 text-sm text-gray-500 truncate font-semibold">
+            normal
+          </span>
+          <div className="flex items-center space-x-4">
+            <div className="flex-shrink-0">
+              <Image
+                width="200"
+                height="200"
+                className="h-8 w-8 rounded-full"
+                src={defaultImg}
+                alt="avatar"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">
+                nickname
+              </p>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-red-900 truncate">VS</p>
+            </div>
+            <div className="flex-shrink-0">
+              <Image
+                width="200"
+                height="200"
+                className="h-8 w-8 rounded-full"
+                src={defaultImg}
+                alt="avatar"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">
+                nickname
+              </p>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default MatchHistory;

--- a/next/src/app/(home)/(communication)/profile/page.tsx
+++ b/next/src/app/(home)/(communication)/profile/page.tsx
@@ -8,6 +8,8 @@ import { useSearchParams } from 'next/navigation';
 import Btn from '@/components/btn';
 import { useState } from 'react';
 import FriendBtn from './_friend/friendBtn';
+import Achievements from './achievements';
+import MatchHistory from './matchHistory';
 
 interface myInfoResponse {
   nickname: string;
@@ -44,6 +46,10 @@ const ProfilePage = () => {
         {!isMyProfile && profile && (
           <FriendBtn id={profile.id} status={profile.friend_status} />
         )}
+        <hr />
+        <MatchHistory />
+        <hr />
+        <Achievements achievements={profile?.achievements} />
       </div>
     </div>
   );

--- a/next/src/app/(home)/(communication)/profile/searchBar.tsx
+++ b/next/src/app/(home)/(communication)/profile/searchBar.tsx
@@ -5,6 +5,11 @@ import { useFetch } from '@/lib/useFetch';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import useSWR from 'swr';
 
+export interface GetAchievementDto {
+  title: string;
+  description: string;
+}
+
 export enum searchUserRequestStatus {
   Allow = 'allow',
   SendRequest = 'send',
@@ -16,6 +21,7 @@ export interface searchProfileResponse {
   nickname: string;
   avata_path: string;
   friend_status: searchUserRequestStatus;
+  achievements: GetAchievementDto[];
 }
 
 export interface searchBarProps {


### PR DESCRIPTION
## 관련 이슈
- close #114 

## 요약
- profile layout 구성 및 achievement를 출력 시켰습니다.
<img width="570" alt="스크린샷" src="https://github.com/august-thirty-first/frontend/assets/48037775/362ac4c8-83a9-42bf-ae0d-2c385aaea12d">


<br><br>

## 작업내용
- achievement data 가져오기 위한 type 추가
- profile page에 achievement data 출력
- matchHistory는 layout만 구성


<br><br>

## 참고사항

<br><br>
