### PR TITLE
[Fix]: useParams의 버그로 인해 props의 인자로 params를 받도록 수정

### DIFF
--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
@@ -1,4 +1,4 @@
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant, {
   ParticipantAuthority,
@@ -8,13 +8,14 @@ import { useShowModal } from '@/app/ShowModalContext';
 import { useContext } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 
-export default function SwitchAuthroity({
+export default function SwitchAuthority({
   participant,
+  roomId,
 }: {
   participant: ChatParticipant;
+  roomId: number;
 }) {
   const targetUserId = participant.user.id;
-  const roomId = useParams().id;
   const authority = participant.authority;
   const isNormal = authority === ParticipantAuthority.NORMAL;
   const router = useRouter();

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
@@ -1,4 +1,4 @@
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import Btn from '@/components/btn';
@@ -6,9 +6,14 @@ import { useContext, useEffect } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import useToast from '@/components/toastContext';
 
-export default function Ban({ participant }: { participant: ChatParticipant }) {
+export default function Ban({
+  participant,
+  roomId,
+}: {
+  participant: ChatParticipant;
+  roomId: number;
+}) {
   const targetUserId = participant.user.id;
-  const roomId = useParams().id;
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const toast = useToast();

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant.tsx
@@ -5,8 +5,10 @@ import ParticipantDetails from '@/app/(home)/(communication)/channel/chat/[id]/_
 
 export default function ChatParticipantList({
   participants,
+  roomId,
 }: {
   participants: ChatParticipant[];
+  roomId: number;
 }) {
   const [showDetails, setShowDetails] = useState<ChatParticipant | null>(null);
 
@@ -26,7 +28,7 @@ export default function ChatParticipantList({
               }}
             />
             {showDetails === participant && (
-              <ParticipantDetails participant={participant} />
+              <ParticipantDetails roomId={roomId} participant={participant} />
             )}
           </div>
         ))}

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/kick.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/kick.tsx
@@ -1,7 +1,5 @@
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
-import { useParams, useRouter } from 'next/navigation';
-import { useShowModal } from '@/app/ShowModalContext';
-import { useFetch } from '@/lib/useFetch';
+import { useRouter } from 'next/navigation';
 import Btn from '@/components/btn';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import { useContext, useEffect } from 'react';
@@ -9,11 +7,12 @@ import useToast from '@/components/toastContext';
 
 export default function Kick({
   participant,
+  roomId,
 }: {
   participant: ChatParticipant;
+  roomId: number;
 }) {
   const targetUserId = participant.user.id;
-  const roomId = useParams().id;
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const toast = useToast();

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/mute.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/mute.tsx
@@ -1,17 +1,18 @@
 import Btn from '@/components/btn';
 import { useContext, useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import useToast from '@/components/toastContext';
 
 export default function Mute({
   participant,
+  roomId,
 }: {
   participant: ChatParticipant;
+  roomId: number;
 }) {
   const targetUserId = participant.user.id;
-  const roomId = useParams().id;
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const toast = useToast();

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/participantDetails.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/participantDetails.tsx
@@ -4,13 +4,15 @@ import ChatParticipant, {
 import Ban from '@/app/(home)/(communication)/channel/chat/[id]/_participant/ban';
 import Kick from '@/app/(home)/(communication)/channel/chat/[id]/_participant/kick';
 import Mute from '@/app/(home)/(communication)/channel/chat/[id]/_participant/mute';
-import SwitchAuthroity from '@/app/(home)/(communication)/channel/chat/[id]/_participant/authroity';
+import SwitchAuthority from '@/app/(home)/(communication)/channel/chat/[id]/_participant/authority';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 
 export default function ParticipantDetails({
   participant,
+  roomId,
 }: {
   participant: ChatParticipant;
+  roomId: number;
 }) {
   const [myParticipantInfo] = useMyParticipantInfo();
 
@@ -19,10 +21,10 @@ export default function ParticipantDetails({
       {(myParticipantInfo?.authority === ParticipantAuthority.BOSS ||
         myParticipantInfo?.authority === ParticipantAuthority.ADMIN) && (
         <>
-          <Ban participant={participant} />
-          <Kick participant={participant} />
-          <Mute participant={participant} />
-          <SwitchAuthroity participant={participant} />
+          <Ban roomId={roomId} participant={participant} />
+          <Kick roomId={roomId} participant={participant} />
+          <Mute roomId={roomId} participant={participant} />
+          <SwitchAuthority roomId={roomId} participant={participant} />
         </>
       )}
     </>

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/chatBox.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/chatBox.tsx
@@ -1,12 +1,9 @@
 'use client';
 import SubmitForm from '@/components/submitForm';
-import { useParams } from 'next/navigation';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 
-export default function ChatBox() {
-  const params = useParams();
-  const roomId = params.id;
+export default function ChatBox({ roomId }: { roomId: number }) {
   const socket = useContext(HomeSocketContext);
   const messageContainerRef = useRef<HTMLDivElement>(null);
   const [messages, setMessages] = useState<string[]>([]);

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
@@ -1,14 +1,11 @@
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import Btn from '@/components/btn';
 import { useContext } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
-import { ParticipantAuthority } from '@/interfaces/chatParticipant.interface';
 
-export default function RoomLeave() {
-  const params = useParams();
-  const roomId = params.id;
+export default function RoomLeave({ roomId }: { roomId: number }) {
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const [myParticipantInfo] = useMyParticipantInfo();

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -2,9 +2,8 @@
 import { useContext } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import ChatBox from '@/app/(home)/(communication)/channel/chat/[id]/chatBox';
-import RoomDelete from '@/app/(home)/(communication)/channel/chat/[id]/delete';
 import RoomBuilder from '@/app/(home)/(communication)/channel/_room/roomBuilder';
-import { useParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant, {
   ParticipantAuthority,
@@ -13,11 +12,10 @@ import RoomLeave from '@/app/(home)/(communication)/channel/chat/[id]/leave';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 import ChatParticipantList from '@/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant';
 
-export default function Chat() {
+export default function Chat({ params }: { params: { id: number } }) {
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const [myParticipantInfo] = useMyParticipantInfo();
-  const params = useParams();
   const roomId = params.id;
   const { isLoading, statusCodeRef, dataRef, bodyRef } = useFetch<
     ChatParticipant[]
@@ -37,14 +35,13 @@ export default function Chat() {
   return (
     dataRef?.current && (
       <div>
-        <ChatParticipantList participants={dataRef.current} />
-        <ChatBox />
+        <ChatParticipantList roomId={roomId} participants={dataRef.current} />
+        <ChatBox roomId={roomId} />
         {/*Todo: 유저의 권한에 대해 확인하고 RoomDelete, RoomUpdate 두 컴포넌트를 보이게 하는 코드 필요*/}
-        <RoomLeave />
+        <RoomLeave roomId={roomId} />
         {(myParticipantInfo?.authority === ParticipantAuthority.BOSS ||
           myParticipantInfo?.authority === ParticipantAuthority.ADMIN) && (
           <>
-            <RoomDelete />
             <RoomBuilder
               title={'방 수정'}
               method={'PATCH'}


### PR DESCRIPTION
## 관련 이슈
close #120 

## 요약
useParams를 사용한 코드를 모두 props로 받도록 변경

<br><br>

## 작업내용
useParams를 사용하여 파라미터를 가져오면 타입이 string | string[]로 고정되어 int로 파싱을 할 수가 없었습니다
따라서 props로 받는 방법으로 변경했습니다

<br><br>

## 참고사항

<br><br>
