### PR TITLE
Hotfix 채팅방 생성 삭제 등 작업시 목록이 갱신되지 않음

### DIFF
--- a/next/src/app/(home)/(communication)/channel/_room/allRoomList.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/allRoomList.tsx
@@ -10,7 +10,11 @@ export default function AllRoomList() {
   return (
     <div>
       <h2> 전체 채팅방 목록 </h2>
-      <RoomList listAPI={'chat'} joinAPI={'chat/register'} />
+      <RoomList
+        listAPI={'chat'}
+        joinAPI={'chat/register'}
+        swrKey={'allRoomList'}
+      />
     </div>
   );
 }

--- a/next/src/app/(home)/(communication)/channel/_room/myRoomList.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/myRoomList.tsx
@@ -4,7 +4,11 @@ export default function MyRoomList() {
   return (
     <div>
       <h2> 내 채팅방 목록 </h2>
-      <RoomList listAPI={'chat/participation'} joinAPI={'chat/enter'} />
+      <RoomList
+        listAPI={'chat/participation'}
+        joinAPI={'chat/enter'}
+        swrKey={'myRoomList'}
+      />
     </div>
   );
 }

--- a/next/src/app/(home)/(communication)/channel/_room/roomBuilder.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomBuilder.tsx
@@ -5,7 +5,8 @@ import { useState } from 'react';
 import Modal from '@/components/modal/Modal';
 import ChatRoom from '@/interfaces/chatRoom.interface';
 import { useRouter } from 'next/navigation';
-import { useShowModal } from '@/app/ShowModalContext';
+import useToast from '@/components/toastContext';
+import { mutate } from 'swr';
 
 export default function RoomBuilder({
   title,
@@ -17,7 +18,7 @@ export default function RoomBuilder({
   url: string;
 }) {
   const router = useRouter();
-  const alertModal = useShowModal();
+  const toast = useToast();
   const [showModal, setShowModal] = useState(false);
   const [inputPassword, setInputPassword] = useState('');
   const [disablePassword, setDisablePassword] = useState(false);
@@ -67,10 +68,13 @@ export default function RoomBuilder({
     Todo: 성공했으면 반환된 채팅방에 redirect
      */
     if (statusCodeRef?.current === 200 || statusCodeRef?.current === 201) {
-      alertModal('성공!');
+      await mutate('allRoomList');
+      await mutate('myRoomList');
+      toast('방 생성 성공');
     } else {
-      alertModal('실패!');
+      toast('방 생성 실패');
     }
+    toggleModal();
   }
 
   return (

--- a/next/src/app/(home)/(communication)/channel/_room/roomDetails.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomDetails.tsx
@@ -3,7 +3,8 @@ import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import Btn from '@/components/btn';
-import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
+import { mutate } from 'swr';
+import useToast from '@/components/toastContext';
 
 export default function RoomDetails({
   room,
@@ -13,7 +14,6 @@ export default function RoomDetails({
   joinAPI: string;
 }) {
   const router = useRouter();
-  const [, setMyParcitipantInfo] = useMyParticipantInfo();
   const { isLoading, statusCodeRef, dataRef, bodyRef, fetchData } =
     useFetch<ChatParticipant>({
       autoFetch: false,
@@ -21,6 +21,7 @@ export default function RoomDetails({
       contentType: 'application/json',
       url: joinAPI,
     });
+  const toast = useToast();
 
   async function joinRoom(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -34,11 +35,12 @@ export default function RoomDetails({
     await fetchData();
     // Todo: 실패 상황일 때 팝업
     if (statusCodeRef?.current !== undefined && statusCodeRef?.current >= 400) {
+      toast('방 입장에 실패했습니다.');
       router.push('/channel');
-    } else {
-      setMyParcitipantInfo(dataRef?.current);
-      router.push(`/channel/chat/${room.id}`);
+      return null;
     }
+    await mutate('myRoomList');
+    router.push(`/channel/chat/${room.id}`);
   }
 
   const requirePassword = room.status === RoomStatus.protected;

--- a/next/src/app/(home)/(communication)/channel/_room/roomList.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomList.tsx
@@ -1,26 +1,28 @@
 'use client';
 import { useFetch } from '@/lib/useFetch';
-import { useRouter } from 'next/navigation';
-import ChatRoom, { RoomStatus } from '@/interfaces/chatRoom.interface';
+import ChatRoom from '@/interfaces/chatRoom.interface';
 import Btn from '@/components/btn';
 import { useState } from 'react';
-import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import RoomDetails from '@/app/(home)/(communication)/channel/_room/roomDetails';
+import useSWR from 'swr';
 
 export default function RoomList({
   listAPI,
   joinAPI,
+  swrKey,
 }: {
   listAPI: string;
   joinAPI: string;
+  swrKey: string;
 }) {
-  const router = useRouter();
-  const { isLoading, dataRef } = useFetch<ChatRoom[]>({
+  const { isLoading, dataRef, fetchData } = useFetch<ChatRoom[]>({
     autoFetch: true,
     method: 'GET',
     url: listAPI,
   });
   const [showDetails, setShowDetails] = useState<number | null>(null);
+
+  useSWR(swrKey, fetchData);
 
   if (isLoading) {
     return <p>Loading..</p>;

--- a/next/src/app/(home)/(communication)/channel/_room/roomList.tsx
+++ b/next/src/app/(home)/(communication)/channel/_room/roomList.tsx
@@ -15,7 +15,7 @@ export default function RoomList({
   joinAPI: string;
   swrKey: string;
 }) {
-  const { isLoading, dataRef, fetchData } = useFetch<ChatRoom[]>({
+  const { dataRef, fetchData } = useFetch<ChatRoom[]>({
     autoFetch: true,
     method: 'GET',
     url: listAPI,
@@ -23,10 +23,6 @@ export default function RoomList({
   const [showDetails, setShowDetails] = useState<number | null>(null);
 
   useSWR(swrKey, fetchData);
-
-  if (isLoading) {
-    return <p>Loading..</p>;
-  }
 
   return (
     <div>

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo.tsx
@@ -1,0 +1,20 @@
+import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
+import { useFetch } from '@/lib/useFetch';
+import ChatParticipant from '@/interfaces/chatParticipant.interface';
+import { useEffect } from 'react';
+
+export default function SetMyParticipantInfo({ roomId }: { roomId: number }) {
+  const [, setMyParticipantInfo] = useMyParticipantInfo();
+  const { isLoading, statusCodeRef, dataRef, bodyRef, fetchData } =
+    useFetch<ChatParticipant>({
+      autoFetch: false,
+      method: 'GET',
+      url: `chat/myParticipant/${roomId}`,
+    });
+
+  useEffect(() => {
+    fetchData().then(() => setMyParticipantInfo(dataRef?.current));
+  }, []);
+
+  return null;
+}

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
@@ -4,9 +4,9 @@ import ChatParticipant, {
   ParticipantAuthority,
 } from '@/interfaces/chatParticipant.interface';
 import Btn from '@/components/btn';
-import { useShowModal } from '@/app/ShowModalContext';
 import { useContext } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
+import useToast from '@/components/toastContext';
 
 export default function SwitchAuthority({
   participant,
@@ -20,7 +20,7 @@ export default function SwitchAuthority({
   const isNormal = authority === ParticipantAuthority.NORMAL;
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
-  const alertModal = useShowModal();
+  const toast = useToast();
   const { statusCodeRef, bodyRef, fetchData } = useFetch<ChatParticipant>({
     autoFetch: false,
     method: 'PATCH',
@@ -38,7 +38,7 @@ export default function SwitchAuthority({
     });
     await fetchData();
     if (statusCodeRef?.current === 200) {
-      // socket.emit('banRoom', JSON.stringify({ roomId: roomId }));
+      toast('권한 변경 성공');
     }
   }
   return (

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
@@ -7,7 +7,6 @@ import Btn from '@/components/btn';
 import { useShowModal } from '@/app/ShowModalContext';
 import { useContext } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
-
 export default function SwitchAuthority({
   participant,
   roomId,
@@ -20,7 +19,7 @@ export default function SwitchAuthority({
   const isNormal = authority === ParticipantAuthority.NORMAL;
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
-  const alertModal = useShowModal();
+  const toast = useToast();
   const { statusCodeRef, bodyRef, fetchData } = useFetch<ChatParticipant>({
     autoFetch: false,
     method: 'PATCH',
@@ -38,7 +37,7 @@ export default function SwitchAuthority({
     });
     await fetchData();
     if (statusCodeRef?.current === 200) {
-      // socket.emit('banRoom', JSON.stringify({ roomId: roomId }));
+      toast('권한 변경 성공');
     }
   }
   return (

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
@@ -24,19 +24,6 @@ export default function Ban({
     url: `chat/participant/${ban}/${participant.user.id}/${roomId}`,
   });
 
-  useEffect(() => {
-    socket.on('ban', msg => {
-      toast(msg);
-      router.push('/channel');
-    });
-    socket.on('banReturnStatus', msg => {
-      toast(msg);
-    });
-    return () => {
-      socket.off('ban');
-    };
-  }, []);
-
   async function banParticipant() {
     await fetchData();
     if (statusCodeRef?.current === 200) {

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/kick.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/kick.tsx
@@ -17,19 +17,6 @@ export default function Kick({
   const socket = useContext(HomeSocketContext);
   const toast = useToast();
 
-  useEffect(() => {
-    socket.on('kickReturnStatus', msg => {
-      toast(msg);
-    });
-    socket.on('kick', msg => {
-      toast(msg);
-      router.push('/channel');
-    });
-    return () => {
-      socket.off('kick');
-    };
-  }, []);
-
   function kickParticipant() {
     socket.emit(
       'kick',

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/mute.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/mute.tsx
@@ -1,5 +1,5 @@
 import Btn from '@/components/btn';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { useRouter } from 'next/navigation';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
@@ -17,14 +17,6 @@ export default function Mute({
   const socket = useContext(HomeSocketContext);
   const toast = useToast();
 
-  useEffect(() => {
-    socket.on('mute', msg => {
-      toast(msg);
-    });
-    socket.on('muteReturnStatus', msg => {
-      toast(msg);
-    });
-  }, []);
   function muteParticipant() {
     socket.emit(
       'mute',

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
@@ -1,9 +1,10 @@
 import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import Btn from '@/components/btn';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
+import { ParticipantAuthority } from '@/interfaces/chatParticipant.interface';
 
 export default function RoomLeave({ roomId }: { roomId: number }) {
   const router = useRouter();
@@ -17,17 +18,22 @@ export default function RoomLeave({ roomId }: { roomId: number }) {
   });
 
   // Todo: 기존에 방에 참여하고 있었던 사용자에 대한 처리 필요
-  // socket.on('leaveRoom', () => {
-  //   leaveRoom();
-  // });
+
+  useEffect(() => {
+    socket.on('deleteRoom', () => {
+      leaveRoom();
+    });
+    return () => {
+      socket.off('deleteRoom');
+    };
+  }, []);
 
   async function leaveRoom() {
     await fetchData();
 
-    // if i am boss? send leaveRoom event
-    // if (myParticipantInfo?.authority === ParticipantAuthority.BOSS) {
-    //   socket.emit('leaveRoom', JSON.stringify({ roomId: roomId }));
-    // }
+    if (myParticipantInfo?.authority === ParticipantAuthority.BOSS) {
+      socket.emit('deleteRoom', JSON.stringify({ roomId: roomId }));
+    }
     router.push(`/channel/`);
   }
 

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/leave.tsx
@@ -1,9 +1,11 @@
 import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import Btn from '@/components/btn';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
+import { ParticipantAuthority } from '@/interfaces/chatParticipant.interface';
+import { mutate } from 'swr';
 
 export default function RoomLeave({ roomId }: { roomId: number }) {
   const router = useRouter();
@@ -17,17 +19,24 @@ export default function RoomLeave({ roomId }: { roomId: number }) {
   });
 
   // Todo: 기존에 방에 참여하고 있었던 사용자에 대한 처리 필요
-  // socket.on('leaveRoom', () => {
-  //   leaveRoom();
-  // });
+
+  useEffect(() => {
+    socket.on('deleteRoom', () => {
+      leaveRoom();
+    });
+    return () => {
+      socket.off('deleteRoom');
+    };
+  }, []);
 
   async function leaveRoom() {
     await fetchData();
 
-    // if i am boss? send leaveRoom event
-    // if (myParticipantInfo?.authority === ParticipantAuthority.BOSS) {
-    //   socket.emit('leaveRoom', JSON.stringify({ roomId: roomId }));
-    // }
+    if (myParticipantInfo?.authority === ParticipantAuthority.BOSS) {
+      socket.emit('deleteRoom', JSON.stringify({ roomId: roomId }));
+    }
+    await mutate('allRoomList');
+    await mutate('myRoomList');
     router.push(`/channel/`);
   }
 

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -23,11 +23,9 @@ function ListenEvent() {
   useEffect(() => {
     socket.on('mute', msg => {
       toast(msg);
-      mutate('participant');
     });
     socket.on('muteReturnStatus', msg => {
       toast(msg);
-      mutate('participant');
     });
     socket.on('kick', msg => {
       toast(msg);

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -64,7 +64,7 @@ export default function Chat({ params }: { params: { id: string } }) {
   const socket = useContext(HomeSocketContext);
   const [myParticipantInfo] = useMyParticipantInfo();
   const roomId = parseInt(params.id);
-  const { isLoading, statusCodeRef, dataRef, bodyRef, fetchData } = useFetch<
+  const { statusCodeRef, dataRef, bodyRef, fetchData } = useFetch<
     ChatParticipant[]
   >({
     autoFetch: true,

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import ChatBox from '@/app/(home)/(communication)/channel/chat/[id]/chatBox';
 import RoomBuilder from '@/app/(home)/(communication)/channel/_room/roomBuilder';
@@ -11,13 +11,62 @@ import ChatParticipant, {
 import RoomLeave from '@/app/(home)/(communication)/channel/chat/[id]/leave';
 import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyParticipantInfoContext';
 import ChatParticipantList from '@/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant';
+import useToast from '@/components/toastContext';
+import SetMyParticipantInfo from '@/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo';
+import useSWR, { mutate } from 'swr';
+
+function ListenEvent() {
+  const socket = useContext(HomeSocketContext);
+  const toast = useToast();
+  const router = useRouter();
+
+  useEffect(() => {
+    socket.on('mute', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    socket.on('muteReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    socket.on('kick', msg => {
+      toast(msg);
+      router.push('/channel');
+      mutate('participant');
+    });
+    socket.on('kickReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    socket.on('ban', msg => {
+      toast(msg);
+      router.push('/channel');
+      mutate('participant');
+    });
+    socket.on('banReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    return () => {
+      socket.off('mute');
+      socket.off('muteReturnStatus');
+      socket.off('deleteRoom');
+      socket.off('kick');
+      socket.off('kickReturnStatus');
+      socket.off('ban');
+      socket.off('banReturnStatus');
+    };
+  }, []);
+
+  return null;
+}
 
 export default function Chat({ params }: { params: { id: string } }) {
   const router = useRouter();
   const socket = useContext(HomeSocketContext);
   const [myParticipantInfo] = useMyParticipantInfo();
   const roomId = parseInt(params.id);
-  const { isLoading, statusCodeRef, dataRef, bodyRef } = useFetch<
+  const { isLoading, statusCodeRef, dataRef, bodyRef, fetchData } = useFetch<
     ChatParticipant[]
   >({
     autoFetch: true,
@@ -25,6 +74,8 @@ export default function Chat({ params }: { params: { id: string } }) {
     contentType: 'application/json',
     url: `chat/allParticipant/${roomId}`,
   });
+
+  useSWR('participant', fetchData);
 
   if (statusCodeRef?.current !== undefined && statusCodeRef?.current >= 400) {
     router.push('/channel');
@@ -35,9 +86,10 @@ export default function Chat({ params }: { params: { id: string } }) {
   return (
     dataRef?.current && (
       <div>
+        <SetMyParticipantInfo roomId={roomId} />
+        <ListenEvent />
         <ChatParticipantList roomId={roomId} participants={dataRef.current} />
         <ChatBox roomId={roomId} />
-        {/*Todo: 유저의 권한에 대해 확인하고 RoomDelete, RoomUpdate 두 컴포넌트를 보이게 하는 코드 필요*/}
         <RoomLeave roomId={roomId} />
         {(myParticipantInfo?.authority === ParticipantAuthority.BOSS ||
           myParticipantInfo?.authority === ParticipantAuthority.ADMIN) && (


### PR DESCRIPTION
## 관련 이슈
- close #103 

## 요약
채팅방 생성, 삭제
유저 ban, kick
등 상태가 변경되어 데이터가 바뀔 경우 갱신이 되도록 구현했습니다.
<br><br>

## 작업내용
SWR을 사용하여 갱신이 필요한 데이터를 다시 렌더링 하도록 구현했습니다.
추가적으로, socket event on 관련 기능을 모두 chat page에서 listen하도록 변경했습니다.

<br><br>

## 참고사항
``` 
SWR key
전체 채팅방 목록 -> allRoomList
내 채팅방 목록 -> myRoomList
채팅 참여자 목록 -> participant
```

<br><br>
