### PR TITLE
뒤로가기, 새로고침 버튼 눌렀을 시 소켓 처리

### DIFF
--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -28,8 +28,7 @@ const gameSocket = isClient
     - game ***
       : renderInfo 읽을 수 없음 에러 발생 (재연결하면서)
 4. 뒤로가기
-    - ladder ***
-      : 소켓이 안 끊어짐
+    - ladder 0
     - option 0
     - game 0
 */

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 import io from 'socket.io-client';
-import { createContext } from 'react';
+import { createContext, useEffect } from 'react';
+import { useModal } from './modalProvider';
 
 const isClient = typeof window !== 'undefined';
 const gameSocket = isClient
@@ -11,6 +12,28 @@ const gameSocket = isClient
 
 export const GameSocketContext = createContext(gameSocket);
 const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
+  const { openModal } = useModal();
+  useEffect(() => {
+    const disconnectListener = () => {
+      openModal('연결이 끊겼습니다..'); //새로고침, 뒤로가기를 포함하여 소켓이 끊기는 모든 상황을 처리하기 위해, 여기서 띄운다
+    };
+    gameSocket.on('disconnect', disconnectListener);
+
+    //새로고침
+    window.addEventListener('beforeunload', event => {
+      gameSocket.disconnect();
+    });
+
+    //뒤로가기
+    window.addEventListener('popstate', event => {
+      gameSocket.disconnect();
+    });
+
+    return () => {
+      gameSocket.off('disconnect', disconnectListener);
+    };
+  }, []);
+
   return (
     <GameSocketContext.Provider value={gameSocket}>
       {children}

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -20,11 +20,8 @@ const gameSocket = isClient
     - game 0
 3. 새로고침
     - ladder ***
-    문제:
-      끊어지고 재연결되면서 다시 큐에 들어가지만, 화면은 profile로 라우팅 되는 상황
-    해결:
-      재연결되는 것도 끊어주거나 (다른 곳에서는 validate로 끊어줌)
-      profile로 라우팅되지 않게 해야 함
+    잘 끊어지고 잘 재연결된다(큐에 중복되지 않음)!
+    다만 여러 번 시도하면 대부분 재연결, 가끔은 재연결되지 않고 profile로 간다.
     - option 0
     한쪽이 끊어지면 서버에서 감지해서 다른 쪽도 알려주고
     끊긴 자신은 홈으로 간다
@@ -47,8 +44,8 @@ const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
     gameSocket.on('disconnect', disconnectListener);
 
     //새로고침
-    // const beforeunloadListener = () => {};
-    // window.addEventListener('beforeunload', beforeunloadListener);
+    const beforeunloadListener = (event: any) => {};
+    window.addEventListener('beforeunload', beforeunloadListener);
 
     //TODO:뒤로가기
     const popstateListener = () => {
@@ -60,6 +57,7 @@ const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
       gameSocket.off('disconnect', disconnectListener);
       // window.removeEventListener('beforeunload', beforeunloadListener);
       window.removeEventListener('popstate', popstateListener);
+      gameSocket.disconnect();
     };
   }, []);
 

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -10,29 +10,56 @@ const gameSocket = isClient
     })
   : io();
 
+/*
+1. validate
+    - option 0
+    - game: 미구현
+2. 동일 유저
+    - ladder 0
+    - option 0
+    - game 0
+3. 새로고침
+    - ladder ***
+    문제:
+      끊어지고 재연결되면서 다시 큐에 들어가지만, 화면은 profile로 라우팅 되는 상황
+    해결:
+      재연결되는 것도 끊어주거나 (다른 곳에서는 validate로 끊어줌)
+      profile로 라우팅되지 않게 해야 함
+    - option 0
+    한쪽이 끊어지면 서버에서 감지해서 다른 쪽도 알려주고
+    끊긴 자신은 홈으로 간다
+    - game ***
+      : renderInfo 읽을 수 없음 에러 발생 (재연결하면서)
+4. 뒤로가기
+    - ladder ***
+      : 소켓이 안 끊어짐
+    - option 0
+    - game 0
+*/
+
 export const GameSocketContext = createContext(gameSocket);
 const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
   useEffect(() => {
     const disconnectListener = () => {
-      // openModal('연결이 끊겼습니다..'); //새로고침, 뒤로가기하면 이 모달창이 안 보인다
-      router.push('/profile'); // 새로고침 시 무시됨. validate를 통해 소켓 연결 안 시켜주는 작업 필요
+      router.push('/profile');
     };
     gameSocket.on('disconnect', disconnectListener);
 
     //새로고침
-    const beforeunloadListener = (event: any) => {
-      event.returnValue = ''; //한 번 더 물어본다. unload를 선택하면 소켓이 끊어지고, 다시 연결되기 전에 바로 홈으로 돌아간다.
-    };
-    window.addEventListener('beforeunload', beforeunloadListener);
+    // const beforeunloadListener = () => {};
+    // window.addEventListener('beforeunload', beforeunloadListener);
 
     //TODO:뒤로가기
-    window.addEventListener('popstate', event => {});
+    const popstateListener = () => {
+      gameSocket.disconnect();
+    };
+    window.addEventListener('popstate', popstateListener);
 
     return () => {
       gameSocket.off('disconnect', disconnectListener);
-      window.removeEventListener('beforeunload', beforeunloadListener);
-      // window.removeEventListener('popstate', popstateListener);
+      // window.removeEventListener('beforeunload', beforeunloadListener);
+      window.removeEventListener('popstate', popstateListener);
     };
   }, []);
 

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -21,15 +21,18 @@ const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
     gameSocket.on('disconnect', disconnectListener);
 
     //새로고침
-    window.addEventListener('beforeunload', event => {
+    const beforeunloadListener = (event: any) => {
       event.returnValue = ''; //한 번 더 물어본다. unload를 선택하면 소켓이 끊어지고, 다시 연결되기 전에 바로 홈으로 돌아간다.
-    });
+    };
+    window.addEventListener('beforeunload', beforeunloadListener);
 
     //TODO:뒤로가기
     window.addEventListener('popstate', event => {});
 
     return () => {
       gameSocket.off('disconnect', disconnectListener);
+      window.removeEventListener('beforeunload', beforeunloadListener);
+      // window.removeEventListener('popstate', popstateListener);
     };
   }, []);
 

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import io from 'socket.io-client';
 import { createContext, useEffect } from 'react';
-import { useModal } from './modalProvider';
+import { useRouter } from 'next/navigation';
 
 const isClient = typeof window !== 'undefined';
 const gameSocket = isClient
@@ -12,22 +12,21 @@ const gameSocket = isClient
 
 export const GameSocketContext = createContext(gameSocket);
 const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
-  const { openModal } = useModal();
+  const router = useRouter();
   useEffect(() => {
     const disconnectListener = () => {
-      openModal('연결이 끊겼습니다..'); //새로고침, 뒤로가기를 포함하여 소켓이 끊기는 모든 상황을 처리하기 위해, 여기서 띄운다
+      // openModal('연결이 끊겼습니다..'); //새로고침, 뒤로가기하면 이 모달창이 안 보인다
+      router.push('/profile'); // 새로고침 시 무시됨. validate를 통해 소켓 연결 안 시켜주는 작업 필요
     };
     gameSocket.on('disconnect', disconnectListener);
 
     //새로고침
     window.addEventListener('beforeunload', event => {
-      gameSocket.disconnect();
+      event.returnValue = ''; //한 번 더 물어본다. unload를 선택하면 소켓이 끊어지고, 다시 연결되기 전에 바로 홈으로 돌아간다.
     });
 
-    //뒤로가기
-    window.addEventListener('popstate', event => {
-      gameSocket.disconnect();
-    });
+    //TODO:뒤로가기
+    window.addEventListener('popstate', event => {});
 
     return () => {
       gameSocket.off('disconnect', disconnectListener);

--- a/next/src/app/(home)/(game)/createGameSocketContext.tsx
+++ b/next/src/app/(home)/(game)/createGameSocketContext.tsx
@@ -13,7 +13,7 @@ const gameSocket = isClient
 /*
 1. validate
     - option 0
-    - game: 미구현
+    - game 0
 2. 동일 유저
     - ladder 0
     - option 0
@@ -21,12 +21,18 @@ const gameSocket = isClient
 3. 새로고침
     - ladder ***
     잘 끊어지고 잘 재연결된다(큐에 중복되지 않음)!
-    다만 여러 번 시도하면 대부분 재연결, 가끔은 재연결되지 않고 profile로 간다.
+    문제:
+    새로고침 버튼으로 소켓이 끊어짐 -> 연결됨이 연쇄적으로 일어나면서,
+    소켓끊김이벤트리스너는 홈으로 가려고 함 vs 새로고침버튼은 새화면으로 가려고 함
+
+    1. 다른 얘들을 각각 처리해주고 disconnect 리스너는 안 만들면 된다.
+    (그러려면 자동끊어지는 validate, 동일유저도 소켓이벤트 받아서 프론트에서 끊어야 함)
+    2. 브라우저에게 맡긴다.
+
     - option 0
     한쪽이 끊어지면 서버에서 감지해서 다른 쪽도 알려주고
     끊긴 자신은 홈으로 간다
-    - game ***
-      : renderInfo 읽을 수 없음 에러 발생 (재연결하면서)
+    - game
 4. 뒤로가기
     - ladder 0
     - option 0
@@ -42,11 +48,7 @@ const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
     };
     gameSocket.on('disconnect', disconnectListener);
 
-    //새로고침
-    const beforeunloadListener = (event: any) => {};
-    window.addEventListener('beforeunload', beforeunloadListener);
-
-    //TODO:뒤로가기
+    //뒤로가기
     const popstateListener = () => {
       gameSocket.disconnect();
     };
@@ -54,7 +56,6 @@ const GameSocketProvider = ({ children }: { children: React.ReactNode }) => {
 
     return () => {
       gameSocket.off('disconnect', disconnectListener);
-      // window.removeEventListener('beforeunload', beforeunloadListener);
       window.removeEventListener('popstate', popstateListener);
       gameSocket.disconnect();
     };

--- a/next/src/app/(home)/(game)/game/gameScreen.tsx
+++ b/next/src/app/(home)/(game)/game/gameScreen.tsx
@@ -19,33 +19,16 @@ const GameScreen: React.FC = () => {
 
   //처음에 한 번만 실행된다
   useEffect(() => {
-    //?를 쓰기는 했으나, useEffect 내에서 실행되므로
-    //사실상 canvasRef를 가져오는 것이 보장된다
-    const canvas = canvasRef.current;
-    const ctx = canvas?.getContext('2d');
+    //소켓 유효성 체크
+    socket.emit('validateSocket');
 
-    if (canvas) {
-      canvas.width = CLIENT_WIDTH;
-      canvas.height = CLIENT_HEIGHT;
-    }
-
-    //undateRenderInfo 이벤트를 받을 준비가 되었음을 알린다.
-    socket.emit(
-      'renderReady',
-      JSON.stringify({
-        clientWidth: CLIENT_WIDTH,
-        clientHeight: CLIENT_HEIGHT,
-      }),
-    );
-
-    //정보 업데이트. 백에서 15ms에 한 번씩 온다
+    /* 아래 모든 함수는 'validateSuccess' 이벤트를 받은 이후 실행된다.
+    못 받을 경우 서버에서 소켓 연결이 끊기면서 /profile로 이동한다. */
     const updateRenderInfoListener = (data: any) => {
       const json = JSON.parse(data);
       renderInfo.update(json.gameMap, json.ball, json.gamePlayers);
     };
-    socket.on('updateRenderInfo', updateRenderInfoListener);
 
-    //게임이 끝나면 모달창을 띄운다
     const gameOverListener = (gameHistory: any) => {
       const json = JSON.parse(gameHistory);
       if (renderInfo.gamePlayers[socket.id].nickName == json.winnerNickname) {
@@ -55,68 +38,96 @@ const GameScreen: React.FC = () => {
         openModal('졌다..');
       }
     };
-    socket.on('gameOver', gameOverListener);
 
-    //중간에 상대방 소켓이 끊어졌을 때 같은 모달창을 띄운다
     const gameOverInPlayingListener = () => {
       openModal('버텨서 이겼다!');
     };
-    socket.on('gameOverInPlaying', gameOverInPlayingListener);
 
-    //키이벤트에 따라 값이 변경된다
-    const keys = {
-      w: {
-        pressed: false,
-      },
-      s: {
-        pressed: false,
-      },
+    const validateSuccessListener = () => {
+      //?를 쓰기는 했으나, useEffect 내에서 실행되므로
+      //사실상 canvasRef를 가져오는 것이 보장된다
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext('2d');
+
+      if (canvas) {
+        canvas.width = CLIENT_WIDTH;
+        canvas.height = CLIENT_HEIGHT;
+      }
+
+      //undateRenderInfo 이벤트를 받을 준비가 되었음을 알린다.
+      socket.emit(
+        'renderReady',
+        JSON.stringify({
+          clientWidth: CLIENT_WIDTH,
+          clientHeight: CLIENT_HEIGHT,
+        }),
+      );
+
+      //정보 업데이트. 백에서 15ms에 한 번씩 온다
+      socket.on('updateRenderInfo', updateRenderInfoListener);
+
+      //게임이 끝나면 모달창을 띄운다
+      socket.on('gameOver', gameOverListener);
+
+      //중간에 상대방 소켓이 끊어졌을 때 같은 모달창을 띄운다
+      socket.on('gameOverInPlaying', gameOverInPlayingListener);
+
+      //키이벤트에 따라 값이 변경된다
+      const keys = {
+        w: {
+          pressed: false,
+        },
+        s: {
+          pressed: false,
+        },
+      };
+
+      window.addEventListener('keydown', event => {
+        if (!renderInfo.gamePlayers[socket.id]) return;
+        switch (event.code) {
+          case 'KeyW':
+            keys.w.pressed = true;
+            break;
+
+          case 'KeyS':
+            keys.s.pressed = true;
+            break;
+        }
+      });
+
+      window.addEventListener('keyup', event => {
+        if (!renderInfo.gamePlayers[socket.id]) return;
+        switch (event.code) {
+          case 'KeyW':
+            keys.w.pressed = false;
+            break;
+
+          case 'KeyS':
+            keys.s.pressed = false;
+            break;
+        }
+      });
+
+      //15ms에 한 번씩 서버에 현재 눌렸는지 값을 보내준다
+      setInterval(() => {
+        if (keys.w.pressed) {
+          renderInfo.gamePlayers[socket.id].bar.position.y -=
+            renderInfo.gamePlayers[socket.id].bar.velocity.y;
+          socket.emit('keyDown', 'keyW');
+        }
+        if (keys.s.pressed) {
+          renderInfo.gamePlayers[socket.id].bar.position.y +=
+            renderInfo.gamePlayers[socket.id].bar.velocity.y;
+          socket.emit('keyDown', 'keyS');
+        }
+      }, 15);
+
+      //재귀함수. 프레임수에 따라 반복해서 화면을 그려준다.
+      if (ctx) {
+        renderInfo.animate(ctx);
+      }
     };
-
-    window.addEventListener('keydown', event => {
-      if (!renderInfo.gamePlayers[socket.id]) return;
-      switch (event.code) {
-        case 'KeyW':
-          keys.w.pressed = true;
-          break;
-
-        case 'KeyS':
-          keys.s.pressed = true;
-          break;
-      }
-    });
-
-    window.addEventListener('keyup', event => {
-      if (!renderInfo.gamePlayers[socket.id]) return;
-      switch (event.code) {
-        case 'KeyW':
-          keys.w.pressed = false;
-          break;
-
-        case 'KeyS':
-          keys.s.pressed = false;
-          break;
-      }
-    });
-
-    //15ms에 한 번씩 서버에 현재 눌렸는지 값을 보내준다
-    setInterval(() => {
-      if (keys.w.pressed) {
-        renderInfo.gamePlayers[socket.id].bar.position.y -=
-          renderInfo.gamePlayers[socket.id].bar.velocity.y;
-        socket.emit('keyDown', 'keyW');
-      }
-      if (keys.s.pressed) {
-        renderInfo.gamePlayers[socket.id].bar.position.y +=
-          renderInfo.gamePlayers[socket.id].bar.velocity.y;
-        socket.emit('keyDown', 'keyS');
-      }
-    }, 15);
-
-    //재귀함수. 프레임수에 따라 반복해서 화면을 그려준다.
-    if (ctx) {
-      renderInfo.animate(ctx);
-    }
+    socket.on('validateSuccess', validateSuccessListener);
 
     //마지막 언마운트에만 실행된다.
     return () => {

--- a/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
+++ b/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
@@ -64,19 +64,11 @@ export default function GameOptionSubmitForm() {
     };
     socket.on('validateSuccess', validateSuccessListener);
 
-    //유효하지 않은 소켓일 때 /profile로 이동
-    const validateFailListener = () => {
-      console.log('validate Fail listener is called');
-      socket.disconnect();
-    };
-    socket.on('validateFail', validateFailListener);
-
     return () => {
       socket.off('gameStart', gameStartListener);
       socket.off('gameOverInOptionPage', gameOverInOptionPageListener);
       socket.off('joinGame', joinGameListener);
       socket.off('validateSuccess', validateSuccessListener);
-      socket.off('validateFail', validateFailListener);
     };
   }, []);
 

--- a/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
+++ b/next/src/components/(home)/(game)/game/gameOptionSubmitForm.tsx
@@ -51,9 +51,32 @@ export default function GameOptionSubmitForm() {
     };
     socket.on('gameOverInOptionPage', gameOverInOptionPageListener);
 
+    //소켓 유효성 체크
+    socket.emit('validateSocket');
+
+    //유효한 소켓일 때 join Queue -> join Game
+    const joinGameListener = () => {
+      router.push('/game/option');
+    };
+    const validateSuccessListener = () => {
+      socket.emit('joinQueue');
+      socket.on('joinGame', joinGameListener);
+    };
+    socket.on('validateSuccess', validateSuccessListener);
+
+    //유효하지 않은 소켓일 때 /profile로 이동
+    const validateFailListener = () => {
+      console.log('validate Fail listener is called');
+      socket.disconnect();
+    };
+    socket.on('validateFail', validateFailListener);
+
     return () => {
       socket.off('gameStart', gameStartListener);
       socket.off('gameOverInOptionPage', gameOverInOptionPageListener);
+      socket.off('joinGame', joinGameListener);
+      socket.off('validateSuccess', validateSuccessListener);
+      socket.off('validateFail', validateFailListener);
     };
   }, []);
 


### PR DESCRIPTION
## 관련 이슈
- #86

## 요약
뒤로가기, 새로고침 버튼 눌렀을 시 소켓 처리

<br><br>

## 작업내용
1. /game 하위의 모든 페이지에서 뒤로가기, 새로고침 버튼 눌렀을 시 소켓 종료하고 홈으로 
2. /game/option, /game에서 큐에 들어있는지 확인하는 validateSocket이벤트를 보내서, success를 받았을 때만 내부 페이지 로드
3. 동일유저가 접속할 경우, validateSocket결과가 fail인 경우 등 서버에서 소켓을 끊었을 때 홈으로

페이지에서 나오면 socket을 무조건 끊어요

<br><br>

## 참고사항
ladder에서 새로고침 했을 때 소켓이벤트리스너(disconnect)와 새로고침버튼이 경합해서 결과가 항상 다른데, 처리할지 논의는 3에서 하려고 합니다.
<br><br>
