### PR TITLE
[bug] match list의 key Props 설정

### DIFF
--- a/next/src/app/(home)/(communication)/profile/matchHistory.tsx
+++ b/next/src/app/(home)/(communication)/profile/matchHistory.tsx
@@ -19,8 +19,8 @@ const MatchHistory = ({ gameData, profileName }: matchHistoryProps) => {
             총 전적 : {gameData.total_win}승 {gameData.total_lose}패 | 점수 : N
           </h3>
           <ul role="list" className="divide-y divide-gray-200">
-            {gameData.game_history.map(history => (
-              <li key={history.winner_avata} className="py-3 sm:py-4">
+            {gameData.game_history.map((history, index) => (
+              <li key={index} className="py-3 sm:py-4">
                 <span
                   className={`inline-flex items-center text-xl font-semibold mb-3 ${
                     profileName === history.winner_nickname


### PR DESCRIPTION
## 관련 이슈
- #142 

## 요약
- 게임 종료후 전적 데이터 오류 수정

<br><br>

## 작업내용
- li key props의 값이 중요한지 몰랐음
- key props의 값은 list에서 고유해야 함으로, index값으로 설정 (이렇게하면 list의 목록을 수정, 삭제, 삽입하면 안됨)

<br><br>

## 참고사항

<br><br>
