### PR TITLE
[fix] otp 로그인 이후에 socket 연결하기

### DIFF
--- a/next/src/app/(login)/otp/page.tsx
+++ b/next/src/app/(login)/otp/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import { useShowModal } from '@/app/ShowModalContext';
 import { useFetch } from '@/lib/useFetch';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 const OtpLogin = () => {
   const [token, setToken] = useState<string>('');
@@ -16,6 +17,7 @@ const OtpLogin = () => {
     body: JSON.stringify({ token }),
     contentType: 'application/json',
   });
+  const socket = useContext(HomeSocketContext);
 
   const validate = (): boolean => {
     const token_trim = token.trim();
@@ -32,7 +34,10 @@ const OtpLogin = () => {
     if (!validate()) return;
     bodyRef.current = JSON.stringify({ token });
     await fetchData();
-    if (statusCodeRef?.current === 200) router.replace('/');
+    if (statusCodeRef?.current === 200) {
+      socket.connect();
+      router.replace('/');
+    }
   };
 
   return (


### PR DESCRIPTION
## 관련 이슈
- #150 

## 요약
- otp 로그인 후 offline 표시 수정

<br><br>

## 작업내용
- context의 HomeSocket이 전역적으로 설정되어 있어서 소켓을 불러올 수 있음
- 로그인 이후에 socket connect 처리하기

<br><br>

## 참고사항

<br><br>
