### PR TITLE
Hotfix unban

### DIFF
--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/ban.tsx
@@ -28,7 +28,7 @@ export default function Ban({
     await fetchData();
     if (statusCodeRef?.current === 200) {
       socket.emit(
-        'ban',
+        ban,
         JSON.stringify({ roomId: roomId, targetUserId: targetUserId }),
       );
     }

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -45,6 +45,10 @@ function ListenEvent() {
       toast(msg);
       mutate('participant');
     });
+    socket.on('unbanReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
     return () => {
       socket.off('mute');
       socket.off('muteReturnStatus');
@@ -53,6 +57,7 @@ function ListenEvent() {
       socket.off('kickReturnStatus');
       socket.off('ban');
       socket.off('banReturnStatus');
+      socket.off('unbanReturnStatus');
     };
   }, []);
 


### PR DESCRIPTION

## 작업내용
- 사용자 unban시 소켓으로 ban event를 보냈었는데, unban event를 보내도록 수정
- unban 이후 다시 버튼이 제대로 갱신되도록 수정

<br><br>

## 참고사항
- 문제 시나리오
admin1, admin2, 사용자1이 있는 상황이라고 가정
admin1이 사용자1을 unban 처리 하였을 경우, admin에겐 사용자1에 대해 'ban' 버튼이 보이지만 admin2에게는 여전히 'unban' 버튼이 표시됨

<br><br>
