### PR TITLE
1:1게임 요청과 수락, 매칭 후 대기페이지(/general) 구현

### DIFF
--- a/next/src/app/(home)/(game)/game/general/page.tsx
+++ b/next/src/app/(home)/(game)/game/general/page.tsx
@@ -3,10 +3,12 @@
 import { useContext, useEffect } from 'react';
 import { GameSocketContext } from '../../createGameSocketContext';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useModal } from '../../modalProvider';
 
 export default function GeneralWaitingPage() {
   const socket = useContext(GameSocketContext);
   const router = useRouter();
+  const { openModal } = useModal();
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -19,9 +21,15 @@ export default function GeneralWaitingPage() {
       socket.emit('generalGameApprove', fromUserId);
     }
 
-    socket.on('joinGame', () => {
+    const matchGameFailListener = () => {
+      openModal('상대방이 떠났습니다..');
+    };
+    socket.on('matchGameFail', matchGameFailListener);
+
+    const joinGameListener = () => {
       router.push('/game/option');
-    });
+    };
+    socket.on('joinGame', joinGameListener);
   }, [socket, router]);
 
   return (

--- a/next/src/app/(home)/(game)/game/general/page.tsx
+++ b/next/src/app/(home)/(game)/game/general/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useContext, useEffect } from 'react';
+import { GameSocketContext } from '../../createGameSocketContext';
+import { useRouter } from 'next/navigation';
+
+export default function GeneralWaitingPage() {
+  const gameSocket = useContext(GameSocketContext);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!gameSocket.connected) {
+      gameSocket.connect();
+    }
+
+    gameSocket.emit('joinQueue');
+
+    gameSocket.on('joinGame', () => {
+      router.push('/game/option');
+    });
+  }, [gameSocket, router]);
+
+  return (
+    <div>
+      <p>게임 상대를 기다리는 중입니다...</p>
+      <div className="text-center">
+        <div role="status">
+          <svg
+            aria-hidden="true"
+            className="w-20 h-20 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+            viewBox="0 0 100 101"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+              fill="currentColor"
+            />
+            <path
+              d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+              fill="currentFill"
+            />
+          </svg>
+          <span className="sr-only">Loading...</span>
+        </div>
+      </div>
+      {/* <CancleMatchBtn /> */}
+    </div>
+  );
+}

--- a/next/src/app/(home)/(game)/game/general/page.tsx
+++ b/next/src/app/(home)/(game)/game/general/page.tsx
@@ -2,23 +2,27 @@
 
 import { useContext, useEffect } from 'react';
 import { GameSocketContext } from '../../createGameSocketContext';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 export default function GeneralWaitingPage() {
-  const gameSocket = useContext(GameSocketContext);
+  const socket = useContext(GameSocketContext);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (!gameSocket.connected) {
-      gameSocket.connect();
+    if (!socket.connected) {
+      socket.connect();
     }
 
-    gameSocket.emit('joinQueue');
+    const fromUserId = searchParams.get('fromUserId');
+    if (fromUserId) {
+      socket.emit('generalGameApprove', fromUserId);
+    }
 
-    gameSocket.on('joinGame', () => {
+    socket.on('joinGame', () => {
       router.push('/game/option');
     });
-  }, [gameSocket, router]);
+  }, [socket, router]);
 
   return (
     <div>

--- a/next/src/app/(home)/(game)/game/general/page.tsx
+++ b/next/src/app/(home)/(game)/game/general/page.tsx
@@ -16,6 +16,10 @@ export default function GeneralWaitingPage() {
       socket.connect();
     }
 
+    const timeoutId = setTimeout(() => {
+      openModal('상대방이 바쁜가봐요..');
+    }, 5000); // 5초
+
     const fromUserId = searchParams.get('fromUserId');
     if (fromUserId) {
       socket.emit('generalGameApprove', fromUserId);
@@ -30,7 +34,14 @@ export default function GeneralWaitingPage() {
       router.push('/game/option');
     };
     socket.on('joinGame', joinGameListener);
-  }, [socket, router]);
+
+    // 컴포넌트 언마운트 시 setTimeout 취소
+    return () => {
+      clearTimeout(timeoutId);
+      socket.off('matchGameFail', matchGameFailListener);
+      socket.off('joinGame', joinGameListener);
+    };
+  }, []);
 
   return (
     <div>

--- a/next/src/app/(home)/createHomeSocketContext.tsx
+++ b/next/src/app/(home)/createHomeSocketContext.tsx
@@ -46,16 +46,19 @@ const HomeSocketProvider = ({ children }: { children: React.ReactNode }) => {
       toast(`${split_msg[0]}님의 메세지가 도착했습니다..`);
     });
     homeSocket.on('waitingPlayer', () => {
-      router.push('/general');
+      router.push('/game/general');
     });
     homeSocket.on('requestGeneralGameError', (msg: string) => {
       toast(msg);
     });
-    homeSocket.on('selectJoin', (fromUserId: number) => {
-      toast(`${fromUserId}님이 게임 초대를 하셨습니다.`, () => {
-        router.push(`/general?userId=${fromUserId}`);
-      });
-    });
+    homeSocket.on(
+      'selectJoin',
+      (fromUserId: number, fromUserNickname: string) => {
+        toast(`${fromUserNickname}님이 게임 초대를 하셨습니다.`, () => {
+          router.push(`/game/general?userId=${fromUserId}`);
+        });
+      },
+    );
     return () => {
       homeSocket.off('selectJoin');
       homeSocket.off('requestGeneralGameError');

--- a/next/src/app/(home)/createHomeSocketContext.tsx
+++ b/next/src/app/(home)/createHomeSocketContext.tsx
@@ -45,7 +45,21 @@ const HomeSocketProvider = ({ children }: { children: React.ReactNode }) => {
       const split_msg = msg.split(':');
       toast(`${split_msg[0]}님의 메세지가 도착했습니다..`);
     });
+    homeSocket.on('waitingPlayer', () => {
+      router.push('/general');
+    });
+    homeSocket.on('requestGeneralGameError', (msg: string) => {
+      toast(msg);
+    });
+    homeSocket.on('selectJoin', (fromUserId: number) => {
+      toast(`${fromUserId}님이 게임 초대를 하셨습니다.`, () => {
+        router.push(`/general?userId=${fromUserId}`);
+      });
+    });
     return () => {
+      homeSocket.off('selectJoin');
+      homeSocket.off('requestGeneralGameError');
+      homeSocket.off('waitingPlayer');
       homeSocket.off('connect');
       homeSocket.off('connection');
       homeSocket.off('multipleConnect');

--- a/next/src/components/friends.tsx
+++ b/next/src/components/friends.tsx
@@ -3,8 +3,8 @@
 import { useFetch } from '@/lib/useFetch';
 import Image from 'next/image';
 import defaultImg from '@/public/default.png';
-import Btn from './btn';
 import useSWR from 'swr';
+import PlayGameBtn from './playGameBtn';
 
 export enum FriendStatus {
   Online = 'online',
@@ -59,8 +59,9 @@ export default function Friends() {
                   </p>
                 </div>
                 <div className="inline-flex items-center text-base font-semibold text-gray-900">
-                  <Btn title="DM" />
-                  <Btn title="PLAY" />
+                  {friend.status === FriendStatus.Online && (
+                    <PlayGameBtn nickname={friend.nickname} />
+                  )}
                 </div>
               </div>
             </li>

--- a/next/src/components/playGameBtn.tsx
+++ b/next/src/components/playGameBtn.tsx
@@ -1,0 +1,34 @@
+import { searchProfileResponse } from '@/app/(home)/(communication)/profile/searchBar';
+import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
+import { useFetch } from '@/lib/useFetch';
+import { useContext } from 'react';
+import Btn from './btn';
+import useToast from './toastContext';
+
+export interface playGameBtnProps {
+  nickname: string;
+}
+
+const PlayGameBtn = ({ nickname }: playGameBtnProps) => {
+  const socket = useContext(HomeSocketContext);
+  const { fetchData, dataRef } = useFetch<searchProfileResponse>({
+    autoFetch: false,
+    url: `profile/user?nickname=${nickname}`,
+    method: 'GET',
+  });
+  const toast = useToast();
+
+  const onClick = async () => {
+    if (confirm('게임 초대를 하시겠습니까?')) {
+      await fetchData();
+      if (dataRef?.current) {
+        const userId = dataRef.current.id;
+        socket.emit('requestGeneralGame', userId);
+      } else toast('찾을 수 없는 사용자입니다.');
+    }
+  };
+
+  return <Btn title="PLAY" handler={onClick} />;
+};
+
+export default PlayGameBtn;

--- a/next/src/components/toast.tsx
+++ b/next/src/components/toast.tsx
@@ -16,6 +16,9 @@ export default function ToastBar({
         toasts.map((toast: ToastProps, index: number) => (
           <div key={index} className={'toast'}>
             <span>{toast.message}</span>
+            {toast.successHandler && (
+              <button onClick={toast.successHandler}>수락</button>
+            )}
             <button onClick={() => onClose(toast.id)}>X</button>
           </div>
         ))}

--- a/next/src/components/toastContext.tsx
+++ b/next/src/components/toastContext.tsx
@@ -11,10 +11,11 @@ import ToastBar from '@/components/toast';
 export interface ToastProps {
   id: number;
   message: string;
+  successHandler?: () => void;
 }
 
 interface ToastContextValue {
-  addToast(message: string): void;
+  addToast(message: string, successHandler?: () => void): void;
 }
 
 const ToastContext = createContext<ToastContextValue>({ addToast: () => {} });
@@ -26,10 +27,11 @@ export function ToastContextProvider({
 }) {
   const [toasts, setToasts] = useState<ToastProps[]>([]);
 
-  const addToast = (message: string) => {
+  const addToast = (message: string, successHandler?: () => void) => {
     const toast: ToastProps = {
       id: Date.now(),
       message: message,
+      successHandler: successHandler,
     };
     setToasts(prevToasts => {
       if (prevToasts.length >= 5) {
@@ -57,8 +59,8 @@ export function ToastContextProvider({
 const useToast = () => {
   const context = useContext(ToastContext);
 
-  return useCallback((message: string) => {
-    context.addToast(message);
+  return useCallback((message: string, successHandler?: () => void) => {
+    context.addToast(message, successHandler);
   }, []);
 };
 


### PR DESCRIPTION
## 관련 이슈
- #87 #161

## 요약
1:1게임 /option 페이지 넘어가기 전까지 구현
<br><br>

## 작업내용
1:1게임을 위한 요청 버튼, 수락 토스트바, general 페이지에서 소켓 이벤트 on, emit 과정을 구현
<br><br>

## 참고사항

<br><br>
