### PR TITLE
Hotfix 채팅방 참여자 상태

### DIFF
--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo.tsx
@@ -2,6 +2,7 @@ import { useMyParticipantInfo } from '@/app/(home)/(communication)/channel/MyPar
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant from '@/interfaces/chatParticipant.interface';
 import { useEffect } from 'react';
+import useSWR from 'swr';
 
 export default function SetMyParticipantInfo({ roomId }: { roomId: number }) {
   const [, setMyParticipantInfo] = useMyParticipantInfo();
@@ -12,9 +13,11 @@ export default function SetMyParticipantInfo({ roomId }: { roomId: number }) {
       url: `chat/myParticipant/${roomId}`,
     });
 
+  const { data } = useSWR('myParticipantInfo', fetchData);
+
   useEffect(() => {
     fetchData().then(() => setMyParticipantInfo(dataRef?.current));
-  }, []);
+  }, [data]);
 
   return null;
 }

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
@@ -40,6 +40,10 @@ export default function SwitchAuthority({
     await fetchData();
     if (statusCodeRef?.current === 200) {
       toast('권한 변경 성공');
+      socket.emit(
+        isNormal ? 'toAdmin' : 'toNormal',
+        JSON.stringify({ roomId: roomId, targetUserId: targetUserId }),
+      );
     }
   }
   return (

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/blackList.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/blackList.tsx
@@ -1,35 +1,22 @@
 import { HomeSocketContext } from '@/app/(home)/createHomeSocketContext';
 import Btn from '@/components/btn';
 import useToast from '@/components/toastContext';
-import ChatParticipant from '@/interfaces/chatParticipant.interface';
+import ChatParticipant, {
+  ChatParticipantWithBlackList,
+} from '@/interfaces/chatParticipant.interface';
 import { useContext, useEffect, useState } from 'react';
 
 export default function BlackList({
   participant,
   roomId,
 }: {
-  participant: ChatParticipant;
+  participant: ChatParticipantWithBlackList;
   roomId: number;
 }) {
   const targetUserId = participant.user.id;
   const socket = useContext(HomeSocketContext);
   const toast = useToast();
-  const [isBlackList, setBlackList] = useState(false);
-
-  useEffect(() => {
-    socket.on('setBlackList', msg => {
-      toast(msg);
-      if (msg === 'set black list success') {
-        setBlackList(true);
-      }
-    });
-    socket.on('unSetBlackList', msg => {
-      toast(msg);
-      if (msg === 'unset black list success') {
-        setBlackList(false);
-      }
-    });
-  }, []);
+  const isBlackList = participant.blackList;
 
   function setBlackListParticipant() {
     socket.emit(

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/chatParticipant.tsx
@@ -1,4 +1,6 @@
-import ChatParticipant from '@/interfaces/chatParticipant.interface';
+import ChatParticipant, {
+  ChatParticipantWithBlackList,
+} from '@/interfaces/chatParticipant.interface';
 import Btn from '@/components/btn';
 import { useState } from 'react';
 import ParticipantDetails from '@/app/(home)/(communication)/channel/chat/[id]/_participant/participantDetails';
@@ -7,31 +9,34 @@ export default function ChatParticipantList({
   participants,
   roomId,
 }: {
-  participants: ChatParticipant[];
+  participants: ChatParticipantWithBlackList[];
   roomId: number;
 }) {
-  const [showDetails, setShowDetails] = useState<ChatParticipant | null>(null);
+  const [showDetails, setShowDetails] =
+    useState<ChatParticipantWithBlackList | null>(null);
 
   return (
     <div>
       <label>참여자 목록</label>
       {participants &&
-        participants.map((participant: ChatParticipant, index: number) => (
-          <div key={index}>
-            <Btn
-              title={`${participant.user.nickname}`}
-              type={'button'}
-              handler={() => {
-                setShowDetails(
-                  showDetails === participant ? null : participant,
-                );
-              }}
-            />
-            {showDetails === participant && (
-              <ParticipantDetails roomId={roomId} participant={participant} />
-            )}
-          </div>
-        ))}
+        participants.map(
+          (participant: ChatParticipantWithBlackList, index: number) => (
+            <div key={index}>
+              <Btn
+                title={`${participant.user.nickname}`}
+                type={'button'}
+                handler={() => {
+                  setShowDetails(
+                    showDetails === participant ? null : participant,
+                  );
+                }}
+              />
+              {showDetails === participant && (
+                <ParticipantDetails roomId={roomId} participant={participant} />
+              )}
+            </div>
+          ),
+        )}
     </div>
   );
 }

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/participantDetails.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/participantDetails.tsx
@@ -1,4 +1,5 @@
 import ChatParticipant, {
+  ChatParticipantWithBlackList,
   ParticipantAuthority,
 } from '@/interfaces/chatParticipant.interface';
 import Ban from '@/app/(home)/(communication)/channel/chat/[id]/_participant/ban';
@@ -12,7 +13,7 @@ export default function ParticipantDetails({
   participant,
   roomId,
 }: {
-  participant: ChatParticipant;
+  participant: ChatParticipantWithBlackList;
   roomId: number;
 }) {
   const [myParticipantInfo] = useMyParticipantInfo();
@@ -26,9 +27,9 @@ export default function ParticipantDetails({
           <Kick roomId={roomId} participant={participant} />
           <Mute roomId={roomId} participant={participant} />
           <SwitchAuthority roomId={roomId} participant={participant} />
-          <BlackList roomId={roomId} participant={participant} />
         </>
       )}
+      <BlackList roomId={roomId} participant={participant} />
     </>
   );
 }

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -6,6 +6,7 @@ import RoomBuilder from '@/app/(home)/(communication)/channel/_room/roomBuilder'
 import { useRouter } from 'next/navigation';
 import { useFetch } from '@/lib/useFetch';
 import ChatParticipant, {
+  ChatParticipantWithBlackList,
   ParticipantAuthority,
 } from '@/interfaces/chatParticipant.interface';
 import RoomLeave from '@/app/(home)/(communication)/channel/chat/[id]/leave';
@@ -41,6 +42,22 @@ function ListenEvent() {
       router.push('/channel');
       mutate('participant');
     });
+    socket.on('toAdmin', msg => {
+      toast(msg);
+      mutate('myParticipantInfo');
+    });
+    socket.on('toNormal', msg => {
+      toast(msg);
+      mutate('myParticipantInfo');
+    });
+    socket.on('toAdminReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    socket.on('toNormalReturnStatus', msg => {
+      toast(msg);
+      mutate('participant');
+    });
     socket.on('banReturnStatus', msg => {
       toast(msg);
       mutate('participant');
@@ -49,6 +66,15 @@ function ListenEvent() {
       toast(msg);
       mutate('participant');
     });
+    socket.on('setBlackList', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+    socket.on('unSetBlackList', msg => {
+      toast(msg);
+      mutate('participant');
+    });
+
     return () => {
       socket.off('mute');
       socket.off('muteReturnStatus');
@@ -56,8 +82,14 @@ function ListenEvent() {
       socket.off('kick');
       socket.off('kickReturnStatus');
       socket.off('ban');
+      socket.off('toAdmin');
+      socket.off('toNormal');
+      socket.off('toAdminReturnStatus');
+      socket.off('toNormalReturnStatus');
       socket.off('banReturnStatus');
       socket.off('unbanReturnStatus');
+      socket.off('setBlackList');
+      socket.off('unSetBlackList');
     };
   }, []);
 
@@ -70,7 +102,7 @@ export default function Chat({ params }: { params: { id: string } }) {
   const [myParticipantInfo] = useMyParticipantInfo();
   const roomId = parseInt(params.id);
   const { statusCodeRef, dataRef, bodyRef, fetchData } = useFetch<
-    ChatParticipant[]
+    ChatParticipantWithBlackList[]
   >({
     autoFetch: true,
     method: 'GET',

--- a/next/src/interfaces/chatParticipant.interface.ts
+++ b/next/src/interfaces/chatParticipant.interface.ts
@@ -15,3 +15,13 @@ export default interface ChatParticipant {
   ban: Date;
   authority_time: Date;
 }
+
+export interface ChatParticipantWithBlackList {
+  id: number;
+  chat_room: ChatRoom;
+  user: User;
+  authority: ParticipantAuthority;
+  ban: Date;
+  authority_time: Date;
+  blackList: boolean;
+}


### PR DESCRIPTION
## 요약
채팅방 참여자 권한과 blackList의 상태 관리
<br><br>

## 작업내용
- 관리자일때랑 아닐때 버튼 title, handle함수 구분
- 권한 바뀐 사용자는 즉시 관리자 전용 버튼 활성화 가능
- blackList는 관리자가 아니여도 버튼 노출
- 채팅방 참여자 정보에 isBlackList 값 보고 버튼 title과 handler함수 변경
<br><br>

## 참고사항

<br><br>
