### PR TITLE
Feat 채팅방 입퇴장 authority바뀔 때도 mutate걸기

### DIFF
--- a/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/_participant/authority.tsx
@@ -39,7 +39,6 @@ export default function SwitchAuthority({
     });
     await fetchData();
     if (statusCodeRef?.current === 200) {
-      toast('권한 변경 성공');
       socket.emit(
         isNormal ? 'toAdmin' : 'toNormal',
         JSON.stringify({ roomId: roomId, targetUserId: targetUserId }),

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -22,7 +22,6 @@ function ListenEvent({ roomId }: { roomId: number }) {
   const router = useRouter();
 
   useEffect(() => {
-    socket.emit('enterRoom', JSON.stringify({ roomId: roomId }));
     socket.on('mute', msg => {
       toast(msg);
     });
@@ -75,6 +74,9 @@ function ListenEvent({ roomId }: { roomId: number }) {
       toast(msg);
       mutate('participant');
     });
+    socket.on('enterRoom', msg => {
+      mutate('participant');
+    });
 
     return () => {
       socket.off('mute');
@@ -91,6 +93,7 @@ function ListenEvent({ roomId }: { roomId: number }) {
       socket.off('unbanReturnStatus');
       socket.off('setBlackList');
       socket.off('unSetBlackList');
+      socket.off('enterRoom');
     };
   }, []);
 

--- a/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
+++ b/next/src/app/(home)/(communication)/channel/chat/[id]/page.tsx
@@ -15,12 +15,13 @@ import useToast from '@/components/toastContext';
 import SetMyParticipantInfo from '@/app/(home)/(communication)/channel/chat/[id]/_participant/SetMyParticipantInfo';
 import useSWR, { mutate } from 'swr';
 
-function ListenEvent() {
+function ListenEvent({ roomId }: { roomId: number }) {
   const socket = useContext(HomeSocketContext);
   const toast = useToast();
   const router = useRouter();
 
   useEffect(() => {
+    socket.emit('enterRoom', JSON.stringify({ roomId: roomId }));
     socket.on('mute', msg => {
       toast(msg);
     });
@@ -79,13 +80,12 @@ export default function Chat({ params }: { params: { id: string } }) {
     router.push('/channel');
     return;
   }
-  socket.emit('enterRoom', JSON.stringify({ roomId: roomId }));
 
   return (
     dataRef?.current && (
       <div>
         <SetMyParticipantInfo roomId={roomId} />
-        <ListenEvent />
+        <ListenEvent roomId={roomId} />
         <ChatParticipantList roomId={roomId} participants={dataRef.current} />
         <ChatBox roomId={roomId} />
         <RoomLeave roomId={roomId} />


### PR DESCRIPTION
## 관련 이슈
- #이슈번호
#170 
## 요약
채팅방 입퇴장 / authority 변경시 소켓 이벤트 관리
<br><br>

## 작업내용
- enterRoom 이벤트 호출 삭제
- 중복된 토스트 삭제
<br><br>

## 참고사항

<br><br>
